### PR TITLE
Add class exists check to OAuthException to avoid compat issue with PECL OAuth

### DIFF
--- a/includes/oauth-php/OAuth.php
+++ b/includes/oauth-php/OAuth.php
@@ -3,8 +3,10 @@
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+if ( ! class_exists('OAuthException') ) {
+	class OAuthException extends Exception {
+	  // pass
+	}
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
Hi Beau,

I know the OAuth lib you use is from another source but this small change makes the plugin compatible with hosts that have the php-oauth module installed. Not too hard to implement on updates of the lib and it will mean Keyring works on hosts like Pantheon where I ran into the issue of it causing a fatal error on activation.