### PR TITLE
Gracefully handle pecl-oauth existing

### DIFF
--- a/includes/oauth-php/OAuth.php
+++ b/includes/oauth-php/OAuth.php
@@ -1,10 +1,8 @@
 <?php
 // vim: foldmethod=marker
 
-/* Generic exception class
- */
-class OAuthException extends Exception {
-  // pass
+if(!class_exists('OAuthException')) {
+  include 'OAuthException.php';
 }
 
 class OAuthConsumer {

--- a/includes/oauth-php/OAuthException.php
+++ b/includes/oauth-php/OAuthException.php
@@ -1,0 +1,7 @@
+<?php
+
+/* Generic exception class
+ */
+class OAuthException extends Exception {
+  // pass
+}


### PR DESCRIPTION
Its possible for the pecl-oauth extension to be on a system
for other requirements. If so it causes a Cannot Redeclare
fatal error and thus a white screen. This fixes that issue.