### PR TITLE
Easier extending of Twitter service

### DIFF
--- a/includes/services/extended/twitter.php
+++ b/includes/services/extended/twitter.php
@@ -70,7 +70,7 @@ class Keyring_Service_Twitter extends Keyring_Service_OAuth1 {
 			);
 		}
 
-		return apply_filters( 'keyring_access_token_meta', $meta, 'twitter', $token, $response, $this );
+		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, $response, $this );
 	}
 
 	function get_display( Keyring_Access_Token $token ) {


### PR DESCRIPTION
Replace `twitter` filter parameter with `$this->get_name()`.

Fixes #15.