### PR TITLE
Update Twitter Callback URL prompt

### DIFF
--- a/includes/services/extended/twitter.php
+++ b/includes/services/extended/twitter.php
@@ -37,7 +37,7 @@ class Keyring_Service_Twitter extends Keyring_Service_OAuth1 {
 	}
 
 	function basic_ui_intro() {
-		echo '<p>' . sprintf( __( 'If you haven\'t already, you\'ll need to <a href="%1$s">create an app on Twitter</a> (log in using your normal Twitter account). Make sure you enter something for the <strong>Callback URL</strong>, even though Keyring will override it with the correct value. Just enter your homepage, e.g. <code>%2$s</code>.', 'keyring' ), 'https://apps.twitter.com/app/new', get_bloginfo( 'url' ) ) . '</p>';
+                echo '<p>' . sprintf( __( 'If you haven\'t already, you\'ll need to <a href="%1$s">create an app on Twitter</a> (log in using your normal Twitter account). The <strong>Callback URL</strong> is <code>%2$s</code>.', 'keyring' ), 'https://apps.twitter.com/app/new', self_admin_url( 'tools.php' ) ) . '</p>';
 		echo '<p>' . __( "Once you've created an app, copy and paste your <strong>Consumer key</strong> and <strong>Consumer secret</strong> (from under the <strong>OAuth settings</strong> section of your app's details) into the boxes below. You don't need an App ID for Twitter.", 'keyring' ) . '</p>';
 	}
 


### PR DESCRIPTION
Twitter now requires the Callback URL to match your wp-admin/tools.php URL (otherwise this will fail with the message `There was a problem connecting to Twitter to create an authorized connection.`). This updates the help text and shows the proper URL to the user.