### PR TITLE
Google Base Service: trim whitespace from api key and secret

### DIFF
--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -195,8 +195,8 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 		if ( isset( $_POST['api_key'] ) && isset( $_POST['api_secret'] ) ) {
 			// Store credentials against this service
 			$this->update_credentials( array(
-				'key'          => stripslashes( $_POST['api_key'] ),
-				'secret'       => stripslashes( $_POST['api_secret'] ),
+				'key'          => stripslashes( trim( $_POST['api_key'] ) ),
+				'secret'       => stripslashes( trim( $_POST['api_secret'] ) ),
 				'redirect_uri' => stripslashes( $_POST['redirect_uri'] ),
 			) );
 			echo '<div class="updated"><p>' . __( 'Credentials saved.', 'keyring' ) . '</p></div>';


### PR DESCRIPTION
It's easy to accidentally include leading and trailing whitespace when copying/pasting the api key and secret from the Google Mail API console. Call 'trim()' on these values before saving them.