### PR TITLE
Google Base Service: use existing refresh token

### DIFF
--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -106,8 +106,20 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 	}
 
 	function build_token_meta( $token ) {
-		$meta = array(
-			'refresh_token' => $token['refresh_token'],
+		$refresh_token = isset( $token['refresh_token'] ) ? $token['refresh_token'] : null;
+
+		if ( ! isset( $refresh_token ) ) {
+			$all_service_tokens = $this->get_tokens();
+			foreach ( $all_service_tokens as $service_token ) {
+				if ( null !== $service_token->get_meta( 'refresh_token' ) ) {
+					$refresh_token = $service_token->get_meta( 'refresh_token' );
+					break;
+				}
+			}
+		}
+
+                $meta = array(
+                        'refresh_token' => $refresh_token,
 			'expires'       => time() + $token['expires_in'],
 		);
 


### PR DESCRIPTION
Fixes #38

Keyring_Service_GoogleBase::build_token_meta() expects that the $token
input will include a 'refresh_token' key. However, there are two cases
where the Google API does not include a refresh token:

1. When 'offline' access has not been requested (for example, in
Keyring's Google Contacts service).
2. When a refresh token has already been provided for the service.

In these cases, a PHP 'Undefined Index' notice is generated by
build_token_meta().

To resolve this issue, check whether the token has a 'refresh_token' key
before trying to use it in the $meta array. If the token does not have a
'refresh_token' key, search the service's existing access tokens for one
with a refresh token. If a refresh token already exists, use it.