### PR TITLE
OAuth2 success response code filter

### DIFF
--- a/includes/services/core/oauth2.php
+++ b/includes/services/core/oauth2.php
@@ -218,7 +218,7 @@ class Keyring_Service_OAuth2 extends Keyring_Service_OAuth1 {
 		Keyring_Util::debug( $res );
 
 		$this->set_request_response_code( wp_remote_retrieve_response_code( $res ) );
-		if ( in_array( wp_remote_retrieve_response_code( $res ), array( 200, 201, 202 ) ) ) {
+		if ( in_array( wp_remote_retrieve_response_code( $res ), apply_filters( 'keyring_' . $this->get_name() . '_success_response_codes', array( 200, 201, 202 ) ) ) ) {
 			if ( $raw_response ) {
 				return wp_remote_retrieve_body( $res );
 			} else {


### PR DESCRIPTION
This PR adds support for filtering success status codes in the OAuth2 request method.
The reason for this is that in some cases the hardcoded status responses (200, 201, 202) are not enough and more flexibility is needed. 

The filter tag is keyring_SERVICE_NAME_success_response_codes where SERVICE_NAME is the name of the service that will get affected by this filter. 

An example is the [Gmail batch modify API endpoint](https://developers.google.com/gmail/api/v1/reference/users/messages/batchModify). On success, the response code is 204. This leads to the request method returning Keyring_Error object.

To test the new feature add this snippet to functions.php. The echo on a loaded page should return Success for both tests.

```
add_action('init', function() {
	//Just a empty page returning 204
	$request_url = 'http://pinkpotato.net/test/204.php';
	$error_class_name = 'Keyring_Error';

	$service = Keyring_Service_OAuth2::init();
	$service->set_token(new Keyring_Access_Token(
		$service->get_name(), 
		'test_token'
	));

	/**
	 * Test 204 without filter
	 */
	echo 'Test 204 return Keyring_Error<br>';
	if( is_a( $service->request( $request_url ), $error_class_name ) ) {
		echo 'Success<br>';
	} else {
		echo 'Error<br>';
	}

	add_filter('keyring_' . $service->get_name() . '_success_response_codes', function($codes) {
		$codes[] = 204;
		return $codes;
	});

	/**
	 * Test 204 with filter
	 */
	echo 'Test 204 return successful response with filter<br>';
	if( is_a( $service->request( $request_url ), $error_class_nam ) ) {
		echo 'Error<br>';
	} else {
		echo 'Success<br>';
	}
});
```