### PR TITLE
Added default URL to cancel forms if referer not set

### DIFF
--- a/includes/services/core/http-basic.php
+++ b/includes/services/core/http-basic.php
@@ -66,6 +66,10 @@ class Keyring_Service_HTTP_Basic extends Keyring_Service {
 
 		echo apply_filters( 'keyring_' . $this->get_name() . '_request_ui_intro', '' );
 
+		$cancel_url = isset($_SERVER['HTTP_REFERER'])
+			? $_SERVER['HTTP_REFERER']
+			: admin_url( 'tools.php?page=' . Keyring::init()->admin_page);
+
 		// Output basic form for collecting user/pass
 		echo '<p>' . sprintf( __( 'Enter your username and password for accessing <strong>%s</strong>:', 'keyring' ), $this->get_label() ) . '</p>';
 		echo '<form method="post" action="">';
@@ -82,7 +86,7 @@ class Keyring_Service_HTTP_Basic extends Keyring_Service {
 		echo '</table>';
 		echo '<p class="submitbox">';
 		echo '<input type="submit" name="submit" value="' . __( 'Verify Details', 'keyring' ) . '" id="submit" class="button-primary">';
-		echo '<a href="' . esc_url( $_SERVER['HTTP_REFERER'] ) . '" class="submitdelete" style="margin-left:2em;">' . __( 'Cancel', 'keyring' ) . '</a>';
+		echo '<a href="' . esc_url( $cancel_url ) . '" class="submitdelete" style="margin-left:2em;">' . __( 'Cancel', 'keyring' ) . '</a>';
 		echo '</p>';
 		echo '</form>';
 		echo '</div>';

--- a/includes/services/core/http-basic.php
+++ b/includes/services/core/http-basic.php
@@ -68,7 +68,7 @@ class Keyring_Service_HTTP_Basic extends Keyring_Service {
 
 		$cancel_url = isset($_SERVER['HTTP_REFERER'])
 			? $_SERVER['HTTP_REFERER']
-			: admin_url( 'tools.php?page=' . Keyring::init()->admin_page);
+			: Keyring_Util::admin_url( $this->get_name() );
 
 		// Output basic form for collecting user/pass
 		echo '<p>' . sprintf( __( 'Enter your username and password for accessing <strong>%s</strong>:', 'keyring' ), $this->get_label() ) . '</p>';

--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -215,6 +215,10 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 			$redirect_uri = Keyring_Util::admin_url( $this->get_name(), array( 'action' => 'verify' ) );
 		}
 
+		$cancel_url = isset($_SERVER['HTTP_REFERER'])
+			? $_SERVER['HTTP_REFERER']
+			: admin_url( 'tools.php?page=' . Keyring::init()->admin_page);
+
 		// Output basic form for collecting key/secret
 		echo '<form method="post" action="">';
 		echo '<input type="hidden" name="service" value="' . esc_attr( $this->get_name() ) . '" />';
@@ -231,7 +235,7 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 		echo '</table>';
 		echo '<p class="submitbox">';
 		echo '<input type="submit" name="submit" value="' . __( 'Save Changes', 'keyring' ) . '" id="submit" class="button-primary">';
-		echo '<a href="' . esc_url( $_SERVER['HTTP_REFERER'] ) . '" class="submitdelete" style="margin-left:2em;">' . __( 'Cancel', 'keyring' ) . '</a>';
+		echo '<a href="' . esc_url( $cancel_url ) . '" class="submitdelete" style="margin-left:2em;">' . __( 'Cancel', 'keyring' ) . '</a>';
 		echo '</p>';
 		echo '</form>';
 		echo '</div>';

--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -217,7 +217,7 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 
 		$cancel_url = isset($_SERVER['HTTP_REFERER'])
 			? $_SERVER['HTTP_REFERER']
-			: admin_url( 'tools.php?page=' . Keyring::init()->admin_page);
+			: Keyring_Util::admin_url( $this->get_name() );
 
 		// Output basic form for collecting key/secret
 		echo '<form method="post" action="">';

--- a/includes/services/extended/instapaper.php
+++ b/includes/services/extended/instapaper.php
@@ -81,6 +81,10 @@ class Keyring_Service_Instapaper extends Keyring_Service_OAuth1 {
 
 		echo apply_filters( 'keyring_' . $this->get_name() . '_request_ui_intro', '' );
 
+		$cancel_url = isset($_SERVER['HTTP_REFERER'])
+			? $_SERVER['HTTP_REFERER']
+			: admin_url( 'tools.php?page=' . Keyring::init()->admin_page);
+
 		// Output basic form for collecting user/pass
 		/* translators: %s: the name of the connection service (instapaper) */
 		echo '<p>' . sprintf( __( 'Enter your username (or email address) and password for accessing <strong>%s</strong>:', 'keyring' ), $this->get_label() ) . '</p>';
@@ -98,7 +102,7 @@ class Keyring_Service_Instapaper extends Keyring_Service_OAuth1 {
 		echo '</table>';
 		echo '<p class="submitbox">';
 		echo '<input type="submit" name="submit" value="' . __( 'Verify Details', 'keyring' ) . '" id="submit" class="button-primary">';
-		echo '<a href="' . esc_attr( $_SERVER['HTTP_REFERER'] ) . '" class="submitdelete" id="logincancel" style="margin-left:2em;">' . __( 'Cancel', 'keyring' ) . '</a>';
+		echo '<a href="' . esc_attr( $cancel_url ) . '" class="submitdelete" id="logincancel" style="margin-left:2em;">' . __( 'Cancel', 'keyring' ) . '</a>';
 		echo '</p>';
 		echo '</form>';
 		echo '</div>';

--- a/includes/services/extended/instapaper.php
+++ b/includes/services/extended/instapaper.php
@@ -83,7 +83,7 @@ class Keyring_Service_Instapaper extends Keyring_Service_OAuth1 {
 
 		$cancel_url = isset($_SERVER['HTTP_REFERER'])
 			? $_SERVER['HTTP_REFERER']
-			: admin_url( 'tools.php?page=' . Keyring::init()->admin_page);
+			: Keyring_Util::admin_url( $this->get_name() );
 
 		// Output basic form for collecting user/pass
 		/* translators: %s: the name of the connection service (instapaper) */

--- a/service.php
+++ b/service.php
@@ -190,9 +190,9 @@ abstract class Keyring_Service {
 
 		echo apply_filters( 'keyring_' . $this->get_name() . '_basic_ui_api_secret', $ui_api_secret );
 
-		$cancel_url = isset($_SERVER['HTTP_REFERER'])
+		$cancel_url = isset( $_SERVER['HTTP_REFERER'] )
 			? $_SERVER['HTTP_REFERER']
-			: admin_url( 'tools.php?page=' . Keyring::init()->admin_page);
+			: Keyring_Util::admin_url( $this->get_name() );
 
 		echo '</table>';
 		echo '<p class="submitbox">';

--- a/service.php
+++ b/service.php
@@ -190,10 +190,14 @@ abstract class Keyring_Service {
 
 		echo apply_filters( 'keyring_' . $this->get_name() . '_basic_ui_api_secret', $ui_api_secret );
 
+		$cancel_url = isset($_SERVER['HTTP_REFERER'])
+			? $_SERVER['HTTP_REFERER']
+			: admin_url( 'tools.php?page=' . Keyring::init()->admin_page);
+
 		echo '</table>';
 		echo '<p class="submitbox">';
 		echo '<input type="submit" name="submit" value="' . __( 'Save Changes', 'keyring' ) . '" id="submit" class="button-primary">';
-		echo '<a href="' . esc_url( $_SERVER['HTTP_REFERER'] ) . '" class="submitdelete" style="margin-left:2em;">' . __( 'Cancel', 'keyring' ) . '</a>';
+		echo '<a href="' . esc_url( $cancel_url ) . '" class="submitdelete" style="margin-left:2em;">' . __( 'Cancel', 'keyring' ) . '</a>';
 		echo '</p>';
 		echo '</form>';
 		?><script type="text/javascript" charset="utf-8">


### PR DESCRIPTION
Resolves issue #51 - sets a default cancel URL if `$_SERVER['HTTP_REFERER']` isn't set.