### PR TITLE
Update the parameters for Google Services to return a refresh token

### DIFF
--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -76,6 +76,10 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 		$class = get_called_class();
 		$params['scope']       = $class::SCOPE;
 		$params['access_type'] = $class::ACCESS_TYPE;
+
+		// Force consent so that we're always given a refresh token
+		$params['prompt'] = 'consent';
+
 		return $params;
 	}
 


### PR DESCRIPTION
If the user has already authorised the application then on subsequent
authorisation flows, consent is not requested and as a result, no
refresh token is returned. The access type is set to `offline` and a
refresh token is always needed, otherwise there is no way to get a new
valid access token.

This change adds the `prompt=consent`query parameter which means that
user consent is requested each time, and the refresh token is returned.

### Testing!

I'm not sure the best way to do it, but you need to go through an authorisation flow of a Google service twice and confirm that you are presented with a consent screen the second time. It will look something like:

<img width="472" alt="image" src="https://user-images.githubusercontent.com/96462/68059222-9810c880-fcf3-11e9-836a-549f593aedd3.png">
