### PR TITLE
Google Base Class: Ensure consistency of the action parameters

### DIFF
--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -171,7 +171,7 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 		);
 
 		// Store the updated access token
-		$access_token = apply_filters( 'keyring_access_token', $access_token, $token );
+		$access_token = apply_filters( 'keyring_access_token', $access_token,  (array) $return );
 		$id = $this->store->update( $access_token );
 
 		// And switch to using it


### PR DESCRIPTION
In the OAuth2 class, after authentication the `keyring_access_token`
filter is applied to the token but the second parameter is an array of
the token data received from the third party service. In the Google Base
class, when refreshing, this parameter is the current
`Keyring_Access_Token` object, and so causees errors on any registered
filter callback functions relying on that value.

This PR changes fixes that. The filter is not being used as part of this
codebase, but it could conceivably break sites that are using this
filter.