### PR TITLE
Eventbrite: Remove some WPCOM-specific code.

### DIFF
--- a/includes/services/extended/eventbrite.php
+++ b/includes/services/extended/eventbrite.php
@@ -14,8 +14,6 @@ class Keyring_Service_Eventbrite extends Keyring_Service_OAuth2 {
 	function __construct() {
 		parent::__construct();
 
-		add_filter( 'keyring_' . $this->get_name() . '_request_token_params', array( $this, 'add_connection_referrer' ) );
-
 		$this->set_endpoint( 'authorize',    self::OAUTH_BASE . 'authorize', 'GET' );
 		$this->set_endpoint( 'access_token', self::OAUTH_BASE . 'token',     'POST' );
 		$this->set_endpoint( 'self',         self::API_BASE . 'users/me/',   'GET' );
@@ -33,23 +31,6 @@ class Keyring_Service_Eventbrite extends Keyring_Service_OAuth2 {
 
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;
-	}
-
-	/**
-	 * Append a referrer to the oAuth request made to Eventbrite, at their request
-	 *
-	 * See http://themedevp2.wordpress.com/2013/12/05/can-we-add-refwpoauth-to/
-	 *
-	 * @param array $params
-	 * @filter keyring_eventbrite_request_token_params
-	 * @return array
-	 */
-	public function add_connection_referrer( $params ) {
-		if ( ! isset( $params['ref'] ) ) {
-			$params['ref'] = 'wpoauth';
-		}
-
-		return $params;
 	}
 
 	function basic_ui_intro() {

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ Add files to includes/services/extended/ that either implement one of the includ
 * Bugfix: Update use of add_submenu_page() to comply with WP 5.3. Props @jhwwp (wp.org) for the fix.
 * Bugfix: Apply the keyring_access_token filter consistently in Google Services. Props @pablinos.
 * Bugfix: Use static "Cancel" URIs in UIs. Props @pgl.
+* Bugfix: Remove some WordPress.com-specific code from Eventbrite.
 
 = 2.0 =
 * Bugfix BREAKING: Remove invalid reference to $this in error handler. Changes number of params passed to keyring_error action.


### PR DESCRIPTION
A little bit of WPCOM code was added to the Eventbrite service a while ago, this PR just tidies it up.