### PR TITLE
Google Drive: Remove an unnecessary constructor.

### DIFF
--- a/includes/services/extended/google-drive.php
+++ b/includes/services/extended/google-drive.php
@@ -14,10 +14,6 @@ class Keyring_Service_Google_Drive extends Keyring_Service_GoogleBase {
 	const SCOPE       = 'profile https://www.googleapis.com/auth/drive.file'; // See https://developers.google.com/identity/protocols/googlescopes#sheetsv4
 	const ACCESS_TYPE = 'offline';
 
-	public function __construct() {
-		parent::__construct();
-	}
-
 	function _get_credentials() {
 		if (
 			defined( 'KEYRING__GOOGLEDRIVE_KEY' ) &&


### PR DESCRIPTION
b81d054d removed some WPCOM-specific stuff from the Google Drive service, but left an empty constructor. This PR tidies it up.