### PR TITLE
Add Multisite support to Keyring

### DIFF
--- a/includes/stores/multistore.php
+++ b/includes/stores/multistore.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * Token storage for a Multi-Site install. Works with multiple users, sharing
+ * connections across multiple sites.
+ *
+ * Stores the tokens in CPTs, and the shared status as postmeta on those posts.
+ *
+ * @package Keyring
+ */
+class Keyring_MultiStore extends Keyring_Store {
+
+	/**
+	 * Initialises the store.
+	 *
+	 * @return Keyring_MultiStore The store instance.
+	 */
+	static function &init() {
+		static $instance = false;
+
+		if ( ! $instance ) {
+			register_post_type(
+				'kr_request_token',
+				array(
+					'label'       => __( 'Keyring Request Token', 'keyring' ),
+					'description' => __( 'Token or authentication details stored by Keyring. Request tokens are used during the authorization flow.', 'keyring' ),
+					'public'      => false,
+				)
+			);
+
+			register_post_type(
+				'kr_access_token',
+				array(
+					'label'       => __( 'Keyring Access Token', 'keyring' ),
+					'description' => __( 'Token or authentication details stored by Keyring. Access tokens are used to make secure requests.', 'keyring' ),
+					'public'      => false,
+				)
+			);
+
+			$instance = new Keyring_MultiStore;
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Inserts a new token in the store.
+	 *
+	 * @param Keyring_Token $token  The token being stored.
+	 * @return int|false The unique ID assigned to the token, or false if it fails to save.
+	 */
+	function insert( $token ) {
+		$site_id = get_current_blog_id();
+		switch_to_blog( KEYRING__MULTI_STORE_SITE_ID );
+
+		// Avoid duplicates by checking to see if this exists already
+		$found = get_posts(
+			array(
+				'posts_per_page' => 1,
+				'post_type'      => 'kr_' . $token->type() . '_token',
+				'meta_key'       => 'service',
+				'meta_value'     => $token->get_name(),
+				'author'         => get_current_user_id(),
+				's'              => serialize( $token->token ), // Search the post content for this token
+				'exact'          => true, // Require exact content match
+				'sentence'       => true, // Require to search by phrase, otherwise string is split by regex
+			)
+		);
+
+		if ( $found ) {
+			$token->unique_id = $found[0]->ID;
+			restore_current_blog();
+			return $this->update( $token, $shared );
+		}
+
+		$post = array(
+			'post_type'    => 'kr_' . $token->type() . '_token',
+			'post_status'  => 'publish',
+			'post_content' => serialize( $token->token ),
+		);
+		$id   = wp_insert_post( add_magic_quotes( $post ) );
+		if ( $id ) {
+			// Always record what service this token is for
+			update_post_meta( $id, 'service', $token->get_name() );
+
+			// Record which site this token was created on, and if it was shared or not.
+			update_post_meta( $id, "shared_$site_id", $shared );
+
+			// Optionally include any meta related to this token
+			foreach ( (array) $token->get_meta( false, true ) as $key => $val ) {
+				update_post_meta( $id, $key, $val );
+			}
+			restore_current_blog();
+			return $id;
+		}
+		restore_current_blog();
+		return false;
+	}
+
+	/**
+	 * Updated an existing token in the store.
+	 *
+	 * @param Keyring_Token $token  The token being stored.
+	 * @return int|false The unique ID assigned to the token, or false if it fails to save.
+	 */
+	function update( $token ) {
+		if ( ! $token->unique_id ) {
+			return false;
+		}
+
+		$site_id = get_current_blog_id();
+		switch_to_blog( KEYRING__MULTI_STORE_SITE_ID );
+
+		$id   = $token->unique_id;
+		$post = get_post( $id );
+		if ( ! $post ) {
+			restore_current_blog();
+			return false;
+		}
+
+		$post->post_content = serialize( $token->token );
+		wp_update_post( $post );
+
+		// Record which site this token was updated on, and if it was shared or not.
+		update_post_meta( $id, "shared_$site_id", $shared );
+
+		foreach ( $token->get_meta( false, true ) as $key => $val ) {
+			update_post_meta( $id, $key, $val );
+		}
+
+		restore_current_blog();
+		return $id;
+	}
+
+	/**
+	 * Deletes an existing token.
+	 *
+	 * @param array $args {
+	 *     @type int $id The unique id of the token to delete.
+	 * }
+	 * @return WP_Post|false The post object of the token being deleted, or false if the delete failed.
+	 */
+	function delete( $args = array() ) {
+		if ( ! $args['id'] ) {
+			return false;
+		}
+
+		switch_to_blog( KEYRING__MULTI_STORE_SITE_ID );
+		$post = wp_delete_post( $args['id'] );
+		restore_current_blog();
+
+		return $post;
+	}
+
+	/**
+	 * Retrieve an array of tokens.
+	 *
+	 * @param array $args {
+	 *     Parameters for selecting which tokens to retrieve.
+	 *
+	 *     @type string       $type    Optional. The token type to retrieve. Valid values are 'access',
+	 *                                 and 'request'. Default 'access'.
+	 *     @type string|false $service Optional. The name of the service to retrieve. To retrieve all services,
+	 *                                 set to `false`. Default `false`.
+	 *     @type int|false    $user_id Optional. Retrieve tokens belonging to this user. To retrieve tokens shared
+	 *                                 with this site by any user, set to `false`. Defaults to the current user id.
+	 *     @type int          $blog_id Optional. Retrieve tokens on this site.
+	 * }
+	 */
+	function get_tokens( $args = array() ) {
+		$defaults = array(
+			'type'    => 'access',
+			'service' => false,
+			'user_id' => get_current_user_id(),
+			'blog_id' => get_current_blog_id(),
+		);
+		$args     = wp_parse_args( $args, $defaults );
+
+		$query = array(
+			'numberposts' => -1, // all
+			'post_type'   => 'kr_' . $args['type'] . '_token',
+			'author'      => $args['user_id'],
+		);
+
+		// Get tokens for a specific service
+		if ( $args['service'] ) {
+			$query['meta_key']   = 'service';
+			$query['meta_value'] = $args['service'];
+		}
+
+		$token_type = 'request' === $args['type'] ? 'Keyring_Request_Token' : 'Keyring_Access_Token';
+		$tokens     = array();
+		$posts      = get_posts( $query );
+		if ( count( $posts ) ) {
+			foreach ( $posts as $post ) {
+				$meta = get_post_meta( $post->ID );
+				foreach ( $meta as $mid => $met ) {
+					$meta[ $mid ] = $met[0];
+				}
+
+				$tokens[] = new $token_type(
+					get_post_meta(
+						$post->ID,
+						'service',
+						true
+					),
+					unserialize( $post->post_content ),
+					$meta,
+					$post->ID
+				);
+			}
+		}
+
+		return $tokens;
+	}
+
+	function get_token( $args = array() ) {
+		$defaults = array(
+			'id'      => false,
+			'type'    => 'access',
+			'service' => false,
+			'user_id' => get_current_user_id(),
+			'blog_id' => get_current_blog_id(),
+		);
+		$args     = wp_parse_args( $args, $defaults );
+
+		if ( ! $args['id'] && ! $args['service'] ) {
+			return false;
+		}
+
+		$post = get_post( $args['id'] );
+		if ( $post ) {
+			$meta = get_post_meta( $post->ID );
+			foreach ( $meta as $mid => $met ) {
+				$meta[ $mid ] = $met[0];
+			}
+
+			$token_type = 'kr_request_token' === $post->post_type ? 'Keyring_Request_Token' : 'Keyring_Access_Token';
+			return new $token_type(
+				get_post_meta(
+					$post->ID,
+					'service',
+					true
+				),
+				unserialize( $post->post_content ),
+				$meta,
+				$post->ID
+			);
+		}
+		return false;
+	}
+
+	function count( $args = array() ) {
+		return count( $this->get_tokens( $args ) );
+	}
+}

--- a/keyring.php
+++ b/keyring.php
@@ -16,6 +16,12 @@ defined( 'KEYRING__DEBUG_MODE' ) or define( 'KEYRING__DEBUG_MODE', false );
 // Optionally define this in your wp-config.php or some other global config file.
 defined( 'KEYRING__TOKEN_STORE' ) or define( 'KEYRING__TOKEN_STORE', 'Keyring_SingleStore' );
 
+// Define this as true in your wp-config.php to enable multi-site functionality.
+defined( 'KEYRING__MULTISITE' ) or define( 'KEYRING__MULTISITE', false );
+
+// When Keyring_MultiStore is in use, it will store all tokens on a particular site.
+defined( 'KEYRING__MULTI_STORE_SITE_ID' ) or define( 'KEYRING__MULTI_STORE_SITE_ID', 1 );
+
 // Keyring can be run in "headless" mode, which just avoids creating any UI, and leaves
 // that up to you. Defaults to off (provides its own basic UI).
 defined( 'KEYRING__HEADLESS_MODE' ) or define( 'KEYRING__HEADLESS_MODE', false );

--- a/token.php
+++ b/token.php
@@ -17,6 +17,9 @@ class Keyring_Token {
 	var $service   = false; // Will contain a Keyring_Service object
 	var $unique_id = false;
 
+	var $owner        = -1;
+	var $shared_sites = array();
+
 	/**
 	 * Create a Keyring_Token instance.
 	 * @param string  $service Shortname for the service this token is for
@@ -113,6 +116,24 @@ class Keyring_Token {
 
 		// Not expired
 		return false;
+	}
+
+	/**
+	 * Setup the owner of this token, usually the WordPress user who created it.
+	 *
+	 * @param int $user_id The owner's user ID.
+	 */
+	function set_owner( $user_id ) {
+		$this->owner = get_user_by( 'id', $user_id );
+	}
+
+	/**
+	 * In a multisite environment, setup a list of the sites this token is shared on.
+	 *
+	 * @param array $site_ids An array of Site IDs.
+	 */
+	function set_shared_sites( $site_ids ) {
+		$this->shared_sites = array_map( 'get_site', (array) $site_ids );
 	}
 }
 


### PR DESCRIPTION
This PR is an _early experiment_ in adding Multsite support to Keyring. Please assume that nothing here works, everything is entirely up for discussion, and it may never actually land in Keyring itself. 🙂

See #10.

## History

This PR is primarily inspired by the WP.com implementation of Keyring and the associated Publicize library, which (amongst other things) provides a way for end users to make a single Keyring connection to an external service, then use that connection on multiple sites, or optionally share that connection with other users on any given site.

For some additional context, Publicize is the WP.com library which handles sharing posts to social media accounts. Social media accounts are a subset of all the accounts Keyring can connect to, but historically, we've never needed to provide multisite-related functionality to non-social media accounts, so these libraries talked to each other, but there was never a need to move that functionality to Keyring.

More recently, we've been building some functionality which would benefit from being able to share non-social media accounts. Rather than trying to hack this into Publicize, it seemed like a good opportunity to drag that functionality out of Publicize, and contribute it to the open source Keyring project. 🙂

## Approach

One of the overarching goals of this PR is to _not_ break backwards compatibility with existing APIs. This is complicated by the new information we need to store along with tokens, and the information we need to expose.

The new data we need to store for a token is: which sites the token owner has opted to shared it with, and whether they're sharing it will all users on each site.

Since `Keyring_Store:insert()` (and sibling methods) only accepts a `Keyring_Token`, this data would need to be set on the token object, to be used by `Keyring_MultiStore` when inserting the token into the database. Unfortunately, this task is complicated, since these methods are called from a wide variety of locations, such as `Keyring_Service::store_token()`, `Keyring_Service_OAuth1::request_token()`, or even on service definitions themselves, such as in `Keyring_Service_Yahoo::maybe_refresh_token()`. Presumably, the store methods are used in similar ways by non-core service defintions. It appears that it would be extremely difficult (if not impossible) to invisibly add multisite support using this route.

Since the act of sharing tokens with other users/sites is closely tied to new UI that currently doesn't exist, it may be possible to work around this by separating the act of creating a token, vs that of sharing a token. Due to time constraints, I haven't explored this option.

If breaking backwards compatibility were an option, we could also look at deprecating or replacing the `Keyring_Service` base class with something that's multisite aware.

We also need to expose new data on the token object: which user the token belongs to, which sites it's been shared with, and whether it's available to all users on each site.

This is complicated by the `Keyring_Token` constructor. It could perhaps be argued that the site/sharing information could be added as magic parameters in the `$meta` argument, but I'm not sure that we can justify doing the same thing with the token owner. It feels like cramming all vaguely related information into the one expandable argument in the constructor.

I started exploring a workaround for this, which you can see in 0324a44: you would create the token object, then add the owner/site information to it. This would be potentially problematic for third party implementations of `Keyring_Store`, as they would need to update how they create token objects.

## What's Next?

I'd like to get feedback from folks on their thoughts on where we can take this. Is breaking back compat an option? Should we explore alternative ways of working around the existing API limitations? (And how many workarounds are too many, since hacks-on-hacks makes for a confusing API to work against in the future?)