### PR TITLE
Add Instragram Basic Display service to support new Instagram APIs

### DIFF
--- a/includes/services/extended/instagram-basic-display.php
+++ b/includes/services/extended/instagram-basic-display.php
@@ -24,15 +24,15 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'refresh_token', 'https://graph.instagram.com/refresh_access_token', 'GET' );
 		$this->set_endpoint( 'self', 'https://graph.instagram.com/me', 'GET' );
 
-		$creds        = $this->get_credentials();
+		$creds = $this->get_credentials();
 
 		$this->app_id = $creds['app_id'];
 		$this->key    = $creds['key'];
 		$this->secret = $creds['secret'];
 
-		// The new Instagram API is very fussy about the redirect uri, so this strips the query params 
+		// The new Instagram API is very fussy about the redirect uri, so this strips the query params
 		// from the default admin url
-		$admin_url = Keyring_Util::admin_url();
+		$admin_url          = Keyring_Util::admin_url();
 		$this->redirect_uri = substr( $admin_url, 0, strpos( $admin_url, '?' ) );
 
 		$this->authorization_header    = false; // Send in querystring
@@ -47,7 +47,7 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 	}
 
 	/**
-	 * Add scope to the outbound URL, and allow developers to modify it, and also 
+	 * Add scope to the outbound URL, and allow developers to modify it, and also
 	 * pack all of the redirct_uri params into the state param as Instagram strips
 	 * these before redirecting
 	 * @param  array $params Core request parameters
@@ -56,14 +56,14 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 	function filter_request_token( $params ) {
 		$params['scope'] = apply_filters( 'keyring_' . $this->get_name() . '_scope', 'user_profile,user_media' );
 
-		// The Instagram API does not return redirect_uri params, so we need to pack these 
+		// The Instagram API does not return redirect_uri params, so we need to pack these
 		// into the state param
 		$url_components = parse_url( $params['redirect_uri'] );
 		parse_str( $url_components['query'], $redirect_state );
 		$redirect_state['state'] = $params['state'];
-		$params['state'] =  Keyring_Util::get_hashed_parameters( $redirect_state );
-		$params['redirect_uri'] = $this->redirect_uri;
-		
+		$params['state']         = Keyring_Util::get_hashed_parameters( $redirect_state );
+		$params['redirect_uri']  = $this->redirect_uri;
+
 		return $params;
 	}
 
@@ -84,11 +84,11 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 		$response = $this->request( add_query_arg( 'fields', 'id, username', $this->self_url ), array( 'method' => $this->self_method ) );
 
 		if ( Keyring_Util::is_error( $response ) ) {
-    		$meta = array();
-    	} else {
+			$meta = array();
+		} else {
 			$meta = array(
-        		'user_id'  => $response->id,
-				'name'     => $response->username,
+				'user_id' => $response->id,
+				'name'    => $response->username,
 			);
 			if ( ! empty( $token['expires_in'] ) ) {
 				$meta['expires'] = time() + $token['expires_in'];
@@ -123,16 +123,16 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 			'grant_type'    => 'ig_exchange_token',
 			'access_token'  => $token['access_token'],
 		);
-		$url = $this->exchange_token_url . '?' . http_build_query( $params );
+		$url    = $this->exchange_token_url . '?' . http_build_query( $params );
 		$result = wp_remote_get( $url );
 		Keyring_Util::debug( 'Instagram Exchange Token Response' );
 		Keyring_Util::debug( $result );
-		if ( 200 == wp_remote_retrieve_response_code( $result ) ) {
+		if ( 200 === wp_remote_retrieve_response_code( $result ) ) {
 			$token = array_merge( $token, (array) json_decode( wp_remote_retrieve_body( $result ) ) );
 			return $token;
 		}
 
-		Keyring::error( __( 'There was a problem exchanging an Instagram access token for a long lived one.' ), array( 'remote_user_id' => $token['user_id'] ) );
+		Keyring::error( __( 'There was a problem exchanging an Instagram access token for a long lived one.', 'keyring' ), array( 'remote_user_id' => $token['user_id'] ) );
 		//TODO: Decide if we should exit here or simply carry on with the short lived token.
 		//It seems like Keyring::error exits at this point anyway.
 		return $token;
@@ -161,17 +161,15 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 			'access_token' => (string) $token,
 		);
 
-
 		$result = wp_remote_get( $this->refresh_token_url . '?' . http_build_query( $params ) );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $result ) ) {
 			return false;
 		}
 
-		$response = json_decode( wp_remote_retrieve_body( $result ) );
-		$meta = $token->get_meta();
+		$response        = json_decode( wp_remote_retrieve_body( $result ) );
+		$meta            = $token->get_meta();
 		$meta['expires'] = time() + $response->expires_in;
-
 
 		// Build access token
 		$access_token = new Keyring_Access_Token(

--- a/includes/services/extended/instagram-basic-display.php
+++ b/includes/services/extended/instagram-basic-display.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Instagram service definition for Keyring.
+ * http://instagram.com/developer/
+ */
+
+class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
+	const NAME  = 'instagram_basic_display';
+	const LABEL = 'Instagram Basic Display';
+
+	function __construct() {
+		parent::__construct();
+
+		// Enable "basic" UI for entering key/secret
+		if ( ! KEYRING__HEADLESS_MODE ) {
+			add_action( 'keyring_' . $this->get_name() . '_manage_ui', array( $this, 'basic_ui' ) );
+			add_filter( 'keyring_i' . $this->get_name() . '_basic_ui_intro', array( $this, 'basic_ui_intro' ) );
+		}
+
+		$this->set_endpoint( 'authorize', 'https://api.instagram.com/oauth/authorize/', 'GET' );
+		$this->set_endpoint( 'access_token', 'https://api.instagram.com/oauth/access_token', 'POST' );
+		$this->set_endpoint( 'self', 'https://graph.instagram.com/me', 'GET' );
+
+		$creds        = $this->get_credentials();
+
+		$this->app_id = $creds['app_id'];
+		$this->key    = $creds['key'];
+		$this->secret = $creds['secret'];
+
+		// The new Instagram API is very fussy about the redirect uri, so this strips the query params 
+		// from the default admin url
+		$admin_url = Keyring_Util::admin_url();
+		$this->redirect_uri = substr($admin_url,0,strpos($admin_url, '?'));
+
+		$this->authorization_header    = false; // Send in querystring
+		$this->authorization_parameter = 'access_token';
+		add_filter( 'keyring_' . $this->get_name() . '_request_token_params', array( $this, 'filter_request_token' ) );
+		add_filter( 'keyring_' . $this->get_name() . '_verify_token_post_params', array( $this, 'verify_token_post_params' ) );
+	}
+
+	function verify_token_post_params( $params ) {
+		$params['body']['redirect_uri'] = $this->redirect_uri;
+		return $params;
+	}
+
+	/**
+	 * Add scope to the outbound URL, and allow developers to modify it, and also 
+	 * pack all of the redirct_uri params into the state param as Instagram strips
+	 * these before redirecting
+	 * @param  array $params Core request parameters
+	 * @return Array containing originals, plus the scope parameter, and a serialized state param
+	 */
+	function filter_request_token( $params ) {
+		$params['scope'] = apply_filters( 'keyring_' . $this->get_name() . '_scope', 'user_profile,user_media' );
+
+		// The Instagram API does not return redirect_uri params, so we need to pack these 
+		// into the state param
+		$url_components = parse_url( $params['redirect_uri'] );
+		parse_str( $url_components['query'], $redirect_state );
+		$redirect_state['state'] = $params['state'];
+		$params['state'] =  Keyring_Util::get_hashed_parameters( $redirect_state );
+		$params['redirect_uri'] = $this->redirect_uri;
+		
+		return $params;
+	}
+
+	function basic_ui_intro() {
+		/* translators: url */
+		echo '<p>' . sprintf( __( 'To get started, <a href="%1$s">register an OAuth client on Instagram</a>. The most important setting is the <strong>OAuth redirect_uri</strong>, which should be set to <code>%2$s</code>. You can set the other values to whatever you like.', 'keyring' ), 'http://instagram.com/developer/clients/register/', Keyring_Util::admin_url( $this->get_name(), array( 'action' => 'verify' ) ) ) . '</p>';
+		echo '<p>' . __( "Once you've saved those changes, copy the <strong>CLIENT ID</strong> value into the <strong>API Key</strong> field, and the <strong>CLIENT SECRET</strong> value into the <strong>API Secret</strong> field and click save (you don't need an App ID value for Instagram).", 'keyring' ) . '</p>';
+	}
+
+	function build_token_meta( $token ) {
+		$this->set_token(
+			new Keyring_Access_Token(
+				$this->get_name(),
+				$token['access_token'],
+				array()
+			)
+		);
+		$response = $this->request( add_query_arg( 'fields', 'id, username', $this->self_url ), array( 'method' => $this->self_method ) );
+
+		if ( Keyring_Util::is_error( $response ) ) {
+            $meta = array();
+        } else {
+            $meta = array(
+                'user_id'  => $response->id,
+                'name'     => $response->username,
+            );
+        }
+
+		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, null, $this );
+	}
+
+	function get_display( Keyring_Access_Token $token ) {
+		return $token->get_meta( 'name' );
+	}
+
+	function test_connection() {
+		$response = $this->request( $this->self_url, array( 'method' => $this->self_method ) );
+		if ( ! Keyring_Util::is_error( $response ) ) {
+			return true;
+		}
+
+		return $response;
+	}
+}
+
+add_action( 'keyring_load_services', array( 'Keyring_Service_Instagram_Basic_Display', 'init' ) );

--- a/includes/services/extended/instagram-basic-display.php
+++ b/includes/services/extended/instagram-basic-display.php
@@ -6,8 +6,8 @@
  */
 
 class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
-	const NAME  = 'instagram_basic_display';
-	const LABEL = 'Instagram Basic Display';
+	const NAME  = 'instagram-basic-display';
+	const LABEL = 'Instagram Basic';
 
 	function __construct() {
 		parent::__construct();
@@ -15,7 +15,7 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 		// Enable "basic" UI for entering key/secret
 		if ( ! KEYRING__HEADLESS_MODE ) {
 			add_action( 'keyring_' . $this->get_name() . '_manage_ui', array( $this, 'basic_ui' ) );
-			add_filter( 'keyring_i' . $this->get_name() . '_basic_ui_intro', array( $this, 'basic_ui_intro' ) );
+			add_filter( 'keyring_' . $this->get_name() . '_basic_ui_intro', array( $this, 'basic_ui_intro' ) );
 		}
 
 		$this->set_endpoint( 'authorize', 'https://api.instagram.com/oauth/authorize/', 'GET' );
@@ -31,7 +31,7 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 		// The new Instagram API is very fussy about the redirect uri, so this strips the query params 
 		// from the default admin url
 		$admin_url = Keyring_Util::admin_url();
-		$this->redirect_uri = substr($admin_url,0,strpos($admin_url, '?'));
+		$this->redirect_uri = substr( $admin_url, 0, strpos( $admin_url, '?' ) );
 
 		$this->authorization_header    = false; // Send in querystring
 		$this->authorization_parameter = 'access_token';
@@ -82,13 +82,13 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 		$response = $this->request( add_query_arg( 'fields', 'id, username', $this->self_url ), array( 'method' => $this->self_method ) );
 
 		if ( Keyring_Util::is_error( $response ) ) {
-            $meta = array();
-        } else {
-            $meta = array(
-                'user_id'  => $response->id,
-                'name'     => $response->username,
-            );
-        }
+			$meta = array();
+		} else {
+			$meta = array(
+				'user_id'  => $response->id,
+				'name'     => $response->username,
+			);
+		}
 
 		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, null, $this );
 	}

--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -44,9 +44,11 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 	}
 
 	/**
-	 * Add scope to the outbound URL, and allow developers to modify it
+	 * Add scope to the outbound URL, and allow developers to modify it, and also 
+	 * pack all of the redirct_uri params into the state param as Instagram does strips
+	 * these before redirecting
 	 * @param  array $params Core request parameters
-	 * @return Array containing originals, plus the scope parameter
+	 * @return Array containing originals, plus the scope parameter, and a serialized state param
 	 */
 	function filter_request_token( $params ) {
 		$params['scope'] = apply_filters( 'keyring_' . $this->get_name() . '_scope', 'user_profile,user_media' );

--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -56,10 +56,10 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 		// The Instagram API does not return redirect_uri params, so we need to pack these 
 		// into the state param
 		$url_components = parse_url( $params['redirect_uri'] );
-		parse_str($url_components['query'], $redirect_state);
+		parse_str( $url_components['query'], $redirect_state );
 		$redirect_state['state'] = $params['state'];
+		$params['state'] =  Keyring_Util::get_hashed_parameters( $redirect_state );
 		$params['redirect_uri'] = $this->redirect_uri;
-		$params['state'] = base64_encode(serialize( $redirect_state ));
 		
 		return $params;
 	}

--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -20,7 +20,7 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 
 		$this->set_endpoint( 'authorize', 'https://api.instagram.com/oauth/authorize/', 'GET' );
 		$this->set_endpoint( 'access_token', 'https://api.instagram.com/oauth/access_token', 'POST' );
-		$this->set_endpoint( 'self', 'https://api.instagram.com/v1/users/self/', 'GET' );
+		$this->set_endpoint( 'self', 'https://graph.instagram.com/me', 'GET' );
 
 		$creds        = $this->get_credentials();
 		$this->app_id = $creds['app_id'];

--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -45,7 +45,7 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 
 	/**
 	 * Add scope to the outbound URL, and allow developers to modify it, and also 
-	 * pack all of the redirct_uri params into the state param as Instagram does strips
+	 * pack all of the redirct_uri params into the state param as Instagram strips
 	 * these before redirecting
 	 * @param  array $params Core request parameters
 	 * @return Array containing originals, plus the scope parameter, and a serialized state param

--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -71,16 +71,23 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 	}
 
 	function build_token_meta( $token ) {
-		if ( empty( $token['user'] ) ) {
-			$meta = array();
-		} else {
-			$meta = array(
-				'user_id'  => $token['user']->id,
-				'username' => $token['user']->username,
-				'name'     => $token['user']->full_name,
-				'picture'  => $token['user']->profile_picture,
-			);
-		}
+		$this->set_token(
+			new Keyring_Access_Token(
+				$this->get_name(),
+				$token['access_token'],
+				array()
+			)
+		);
+		$response = $this->request( add_query_arg( 'fields', 'id, username', $this->self_url ), array( 'method' => $this->self_method ) );
+
+		if ( Keyring_Util::is_error( $response ) ) {
+            $meta = array();
+        } else {
+            $meta = array(
+                'user_id'  => $response->id,
+                'name'     => $response->username,
+            );
+        }
 
 		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, null, $this );
 	}

--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -18,91 +18,49 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 			add_filter( 'keyring_instagram_basic_ui_intro', array( $this, 'basic_ui_intro' ) );
 		}
 
-		$this->set_endpoint( 'authorize', 'https://api.instagram.com/oauth/authorize/', 'GET' );
+		$this->set_endpoint( 'authorize',    'https://api.instagram.com/oauth/authorize/',   'GET'  );
 		$this->set_endpoint( 'access_token', 'https://api.instagram.com/oauth/access_token', 'POST' );
-		$this->set_endpoint( 'self', 'https://graph.instagram.com/me', 'GET' );
+		$this->set_endpoint( 'self',         'https://api.instagram.com/v2/users/self',      'GET'  );
 
-		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		$creds = $this->get_credentials();
+		$this->app_id  = $creds['app_id'];
+		$this->key     = $creds['key'];
+		$this->secret  = $creds['secret'];
 
-		// The new Instagram API is very fussy about the redirect uri, so this strips the query params 
-		// from the default admin url
-		$admin_url = Keyring_Util::admin_url();
-		$this->redirect_uri = substr($admin_url,0,strpos($admin_url, '?'));
+		$this->consumer = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
+		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;
 
 		$this->authorization_header    = false; // Send in querystring
 		$this->authorization_parameter = 'access_token';
-		add_filter( 'keyring_instagram_request_token_params', array( $this, 'filter_request_token' ) );
-		add_filter( 'keyring_instagram_verify_token_post_params', array( $this, 'verify_token_post_params' ) );
-	}
-
-	function verify_token_post_params( $params ) {
-		$params['body']['redirect_uri'] = $this->redirect_uri;
-		return $params;
-	}
-
-	/**
-	 * Add scope to the outbound URL, and allow developers to modify it, and also 
-	 * pack all of the redirct_uri params into the state param as Instagram strips
-	 * these before redirecting
-	 * @param  array $params Core request parameters
-	 * @return Array containing originals, plus the scope parameter, and a serialized state param
-	 */
-	function filter_request_token( $params ) {
-		$params['scope'] = apply_filters( 'keyring_' . $this->get_name() . '_scope', 'user_profile,user_media' );
-
-		// The Instagram API does not return redirect_uri params, so we need to pack these 
-		// into the state param
-		$url_components = parse_url( $params['redirect_uri'] );
-		parse_str( $url_components['query'], $redirect_state );
-		$redirect_state['state'] = $params['state'];
-		$params['state'] =  Keyring_Util::get_hashed_parameters( $redirect_state );
-		$params['redirect_uri'] = $this->redirect_uri;
-		
-		return $params;
 	}
 
 	function basic_ui_intro() {
-		/* translators: url */
-		echo '<p>' . sprintf( __( 'To get started, <a href="%1$s">register an OAuth client on Instagram</a>. The most important setting is the <strong>OAuth redirect_uri</strong>, which should be set to <code>%2$s</code>. You can set the other values to whatever you like.', 'keyring' ), 'http://instagram.com/developer/clients/register/', Keyring_Util::admin_url( $this->get_name(), array( 'action' => 'verify' ) ) ) . '</p>';
+		echo '<p>' . sprintf( __( 'To get started, <a href="%1$s">register an OAuth client on Instagram</a>. The most important setting is the <strong>OAuth redirect_uri</strong>, which should be set to <code>%2$s</code>. You can set the other values to whatever you like.', 'keyring' ), 'http://instagram.com/developer/clients/register/', Keyring_Util::admin_url( 'instagram', array( 'action' => 'verify' ) ) ) . '</p>';
 		echo '<p>' . __( "Once you've saved those changes, copy the <strong>CLIENT ID</strong> value into the <strong>API Key</strong> field, and the <strong>CLIENT SECRET</strong> value into the <strong>API Secret</strong> field and click save (you don't need an App ID value for Instagram).", 'keyring' ) . '</p>';
 	}
 
 	function build_token_meta( $token ) {
-		$this->set_token(
-			new Keyring_Access_Token(
-				$this->get_name(),
-				$token['access_token'],
-				array()
-			)
-		);
-		$response = $this->request( add_query_arg( 'fields', 'id, username', $this->self_url ), array( 'method' => $this->self_method ) );
+		if ( empty( $token['user'] ) ) {
+			$meta = array();
+		} else {
+			$meta = array(
+				'user_id'  => $token['user']->id,
+				'username' => $token['user']->username,
+				'name'     => $token['user']->full_name,
+				'picture'  => $token['user']->profile_picture,
+			);
+		}
 
-		if ( Keyring_Util::is_error( $response ) ) {
-            $meta = array();
-        } else {
-            $meta = array(
-                'user_id'  => $response->id,
-                'name'     => $response->username,
-            );
-        }
-
-		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, null, $this );
+		return apply_filters( 'keyring_access_token_meta', $meta, 'instagram', $token, null, $this );
 	}
 
 	function get_display( Keyring_Access_Token $token ) {
 		return $token->get_meta( 'name' );
 	}
 
-	function test_connection() {
-		$response = $this->request( $this->self_url, array( 'method' => $this->self_method ) );
-		if ( ! Keyring_Util::is_error( $response ) ) {
-			return true;
-		}
-
-		return $response;
+	function fetch_profile_picture() {
+		$res = $this->request( $this->self_url, array( 'method' => $this->self_method ) );
+		return empty( $res->data->profile_picture ) ? null : esc_url_raw( $res->data->profile_picture );
 	}
 }
 

--- a/keyring.php
+++ b/keyring.php
@@ -129,7 +129,7 @@ class Keyring {
 	 */
 	static function request_handlers() {
 		global $current_user;
-		
+
 		if ( ! empty( $_REQUEST['state'] ) ) {
 			Keyring_Util::unpack_state_parameters( $_REQUEST['state'] );
 		}
@@ -338,7 +338,7 @@ class Keyring_Util {
 	 * @return void
 	 */
 	static function unpack_state_parameters( $state ) {
-		$unpacked_state =  unserialize( base64_decode( $state ) );
+		$unpacked_state = unserialize( base64_decode( $state ) );
 		if ( ! empty( $unpacked_state['hash'] ) ) {
 			$validated_parameters = Keyring_Util::get_validated_parameters( $unpacked_state );
 
@@ -347,7 +347,7 @@ class Keyring_Util {
 				exit;
 			}
 
-			foreach ( $validated_parameters as $key => $value) {
+			foreach ( $validated_parameters as $key => $value ) {
 				$_REQUEST[ $key ] = $value;
 			}
 
@@ -392,7 +392,7 @@ class Keyring_Util {
 		$return_hash = $parameters['hash'];
 		unset( $parameters['hash'] );
 
-		if ( $return_hash !== self::get_parameter_hash( serialize( $parameters ) ) ) {
+		if ( self::get_parameter_hash( serialize( $parameters ) ) !== $return_hash ) {
 			return false;
 		}
 

--- a/keyring.php
+++ b/keyring.php
@@ -129,6 +129,18 @@ class Keyring {
 	 */
 	static function request_handlers() {
 		global $current_user;
+		
+		// Some services do not return the redirect_uri params, in this case these are packed into the state param.
+		// If so, they are unpacked again here and merged back into the request globals.
+		if ( ! empty( $_REQUEST['state'] ) ) {
+			$unpacked_state = unserialize( base64_decode( $_REQUEST['state'] ) );
+			if ( ! empty( $unpacked_state['action'] )) {
+				foreach ( $unpacked_state as $key => $value) {
+					$_REQUEST[ $key ] = $value;
+				}
+				$_GET['state'] = $unpacked_state['state'];
+			}
+		}
 
 		if ( defined( 'KEYRING__FORCE_USER' ) && KEYRING__FORCE_USER && in_array( $_REQUEST['action'], array( 'request', 'verify' ), true ) ) {
 			global $current_user;

--- a/keyring.php
+++ b/keyring.php
@@ -134,9 +134,10 @@ class Keyring {
 		// If so, they are unpacked again here and merged back into the request globals.
 		if ( ! empty( $_REQUEST['state'] ) ) {
 			$unpacked_state =  unserialize( base64_decode( $_REQUEST['state'] ) );
-			
 			if ( ! empty( $unpacked_state['hash'] ) ) {
-				if ( ! $validated_parameters = Keyring_Util::get_validated_parameters( $unpacked_state ) ) {
+				$validated_parameters = Keyring_Util::get_validated_parameters( $unpacked_state );
+				
+				if ( ! $validated_parameters ) {
 					Keyring::error( __( 'Invalid data returned by the service. Please try again.', 'keyring' ) );
 					exit;
 				}


### PR DESCRIPTION
On 31 March 2020 Instragram will be retiring its existing API and retrieving a user's media will require use of the the new [Basic Display API](ttps://developers.facebook.com/docs/instagram-basic-display-api ). 

This PR modifies the existing Instgram external service to make use of this new API.

Testing:

- Check out this branch in local WP install
- Add an Instagram connection (you will need an Instagram App ID and secret for the new Basic Display API)
- Make sure you can add and test the Instagram connection