### PR TITLE
Remove pass by reference operator to prevent warnings in PHP7

### DIFF
--- a/admin-ui.php
+++ b/admin-ui.php
@@ -19,7 +19,7 @@ class Keyring_Admin_UI {
 		add_filter( 'plugin_action_links_' . plugin_basename( __DIR__ ) . '/keyring.php', array( $this, 'settings_link' ) );
 	}
 
-	static function &init() {
+	static function init() {
 		static $instance = false;
 
 		if ( ! $instance ) {

--- a/includes/stores/singlestore.php
+++ b/includes/stores/singlestore.php
@@ -10,7 +10,7 @@
 class Keyring_SingleStore extends Keyring_Store {
 	var $unique_id = false;
 
-	static function &init() {
+	static function init() {
 		static $instance = false;
 
 		if ( ! $instance ) {

--- a/keyring.php
+++ b/keyring.php
@@ -63,7 +63,7 @@ class Keyring {
 		$this->admin_page = apply_filters( 'keyring_admin_page', 'keyring' );
 	}
 
-	static function &init( $force_load = false ) {
+	static function init( $force_load = false ) {
 		static $instance = false;
 
 		if ( ! $instance ) {

--- a/service.php
+++ b/service.php
@@ -69,7 +69,7 @@ abstract class Keyring_Service {
 		add_action( 'keyring_' . $this->get_name() . '_verify', array( $this, 'verify_token' ) );
 	}
 
-	static function &init() {
+	static function init() {
 		static $instance = false;
 
 		if ( ! $instance ) {

--- a/store.php
+++ b/store.php
@@ -12,7 +12,7 @@ abstract class Keyring_Store {
 	/**
 	 * Any set up required to initiate this storage engine.
 	 */
-	static function &init() {}
+	static function init() {}
 
 	/**
 	 * Insert a new token into this storage engine.


### PR DESCRIPTION
If we don't need to be support PHP4 now then this should be removed to prevent unnecessary warnings