### PR TITLE
oauth lib: Replace relative includes to prevent linting errors

### DIFF
--- a/includes/oauth-php/tests/OAuthConsumerTest.php
+++ b/includes/oauth-php/tests/OAuthConsumerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require 'common.php';
+require_once dirname(__FILE__) . '/common.php';
 
 class OAuthConsumerTest extends PHPUnit\Framework\TestCase {
 	public function testConvertToString() {

--- a/includes/oauth-php/tests/OAuthSignatureMethodHmacSha1Test.php
+++ b/includes/oauth-php/tests/OAuthSignatureMethodHmacSha1Test.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once 'common.php';
-require_once 'Mock_OAuthBaseStringRequest.php';
+require_once dirname(__FILE__) . '/common.php';
+require_once dirname(__FILE__) . '/Mock_OAuthBaseStringRequest.php';
 
 class OAuthSignatureMethodHmacSha1Test extends PHPUnit\Framework\TestCase {
 	private $method;

--- a/includes/oauth-php/tests/OAuthSignatureMethodPlaintextTest.php
+++ b/includes/oauth-php/tests/OAuthSignatureMethodPlaintextTest.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once 'common.php';
-require_once 'Mock_OAuthBaseStringRequest.php';
+require_once dirname(__FILE__) . '/common.php';
+require_once dirname(__FILE__) . '/Mock_OAuthBaseStringRequest.php';
 
 class OAuthSignatureMethodPlaintextTest extends PHPUnit\Framework\TestCase {
 	private $method;

--- a/includes/oauth-php/tests/OAuthSignatureMethodRsaSha1Test.php
+++ b/includes/oauth-php/tests/OAuthSignatureMethodRsaSha1Test.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once 'common.php';
-require_once 'Mock_OAuthBaseStringRequest.php';
-require_once 'Mock_OAuthSignatureMethod_RSA_SHA1.php';
+require_once dirname(__FILE__) . '/common.php';
+require_once dirname(__FILE__) . '/Mock_OAuthBaseStringRequest.php';
+require_once dirname(__FILE__) . '/Mock_OAuthSignatureMethod_RSA_SHA1.php';
 
 class OAuthSignatureMethodRsaSha1Test extends PHPUnit\Framework\TestCase {
 	private $method;

--- a/includes/oauth-php/tests/OAuthTokenTest.php
+++ b/includes/oauth-php/tests/OAuthTokenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'common.php';
+require_once dirname(__FILE__) . '/common.php';
 
 class OAuthTokenTest extends PHPUnit\Framework\TestCase {
 	public function testSerialize() {


### PR DESCRIPTION
Just updates some of the includes in tests folder to prevent linting errors.