### PR TITLE
Google/Moves/Fitbit: Add response to token meta filter

### DIFF
--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -131,7 +131,7 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 			$meta['picture'] = $response->picture;
 		}
 
-		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, array(), $this );
+		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, $response, $this );
 	}
 
 	function get_display( Keyring_Access_Token $token ) {

--- a/includes/services/extended/fitbit.php
+++ b/includes/services/extended/fitbit.php
@@ -124,7 +124,7 @@ class Keyring_Service_Fitbit extends Keyring_Service_OAuth2 {
 			$meta['first_date'] = $response->user->memberSince;
 		}
 
-		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, array(), $this );
+		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, $response, $this );
 	}
 
 	function get_display( Keyring_Access_Token $token ) {

--- a/includes/services/extended/moves.php
+++ b/includes/services/extended/moves.php
@@ -106,7 +106,7 @@ class Keyring_Service_Moves extends Keyring_Service_OAuth2 {
 			$meta['first_date'] = $response->profile->firstDate;
 		}
 
-		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, array(), $this );
+		return apply_filters( 'keyring_access_token_meta', $meta, $this->get_name(), $token, $response, $this );
 	}
 
 	function get_display( Keyring_Access_Token $token ) {


### PR DESCRIPTION
### Description

Makes it easier for developers to add additional metadata with the existing response object (as it is already done for other services). Change adds `$response` to `apply_filters(...)` call instead of `array()` for Moves, Fitbit and all Google services.

### Testing

For Google, Moves and Fitbit:
Add a filter for `keyring_access_token_meta` and ensure the 4th param is the response from the additional user data request (e.g. `/userinfo` for Google) when filter is called.

Fixes #80