### PR TITLE
Fix deprecation/notices when running on PHP 7.4

### DIFF
--- a/includes/oauth-php/OAuth.php
+++ b/includes/oauth-php/OAuth.php
@@ -100,7 +100,7 @@ abstract class OAuthSignatureMethod {
     // Avoid a timing leak with a (hopefully) time insensitive compare
     $result = 0;
     for ($i = 0; $i < strlen($signature); $i++) {
-      $result |= ord($built{$i}) ^ ord($signature{$i});
+      $result |= ord($built{$i}) ^ ord($signature[$i]);
     }
 
     return $result == 0;
@@ -108,9 +108,9 @@ abstract class OAuthSignatureMethod {
 }
 
 /**
- * The HMAC-SHA1 signature method uses the HMAC-SHA1 signature algorithm as defined in [RFC2104] 
- * where the Signature Base String is the text and the key is the concatenated values (each first 
- * encoded per Parameter Encoding) of the Consumer Secret and Token Secret, separated by an '&' 
+ * The HMAC-SHA1 signature method uses the HMAC-SHA1 signature algorithm as defined in [RFC2104]
+ * where the Signature Base String is the text and the key is the concatenated values (each first
+ * encoded per Parameter Encoding) of the Consumer Secret and Token Secret, separated by an '&'
  * character (ASCII code 38) even if empty.
  *   - Chapter 9.2 ("HMAC-SHA1")
  */
@@ -136,7 +136,7 @@ class OAuthSignatureMethod_HMAC_SHA1 extends OAuthSignatureMethod {
 }
 
 /**
- * The PLAINTEXT method does not provide any security protection and SHOULD only be used 
+ * The PLAINTEXT method does not provide any security protection and SHOULD only be used
  * over a secure channel such as HTTPS. It does not use the Signature Base String.
  *   - Chapter 9.4 ("PLAINTEXT")
  */
@@ -146,8 +146,8 @@ class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod {
   }
 
   /**
-   * oauth_signature is set to the concatenated encoded values of the Consumer Secret and 
-   * Token Secret, separated by a '&' character (ASCII code 38), even if either secret is 
+   * oauth_signature is set to the concatenated encoded values of the Consumer Secret and
+   * Token Secret, separated by a '&' character (ASCII code 38), even if either secret is
    * empty. The result MUST be encoded again.
    *   - Chapter 9.4.1 ("Generating Signatures")
    *
@@ -169,10 +169,10 @@ class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod {
 }
 
 /**
- * The RSA-SHA1 signature method uses the RSASSA-PKCS1-v1_5 signature algorithm as defined in 
- * [RFC3447] section 8.2 (more simply known as PKCS#1), using SHA-1 as the hash function for 
- * EMSA-PKCS1-v1_5. It is assumed that the Consumer has provided its RSA public key in a 
- * verified way to the Service Provider, in a manner which is beyond the scope of this 
+ * The RSA-SHA1 signature method uses the RSASSA-PKCS1-v1_5 signature algorithm as defined in
+ * [RFC3447] section 8.2 (more simply known as PKCS#1), using SHA-1 as the hash function for
+ * EMSA-PKCS1-v1_5. It is assumed that the Consumer has provided its RSA public key in a
+ * verified way to the Service Provider, in a manner which is beyond the scope of this
  * specification.
  *   - Chapter 9.3 ("RSA-SHA1")
  */
@@ -573,7 +573,7 @@ class OAuthServer {
   private function get_version(&$request) {
     $version = $request->get_parameter("oauth_version");
     if (!$version) {
-      // Service Providers MUST assume the protocol version to be 1.0 if this parameter is not present. 
+      // Service Providers MUST assume the protocol version to be 1.0 if this parameter is not present.
       // Chapter 7.0 ("Accessing Protected Ressources")
       $version = '1.0';
     }
@@ -587,7 +587,7 @@ class OAuthServer {
    * figure out the signature with some defaults
    */
   private function get_signature_method($request) {
-    $signature_method = $request instanceof OAuthRequest 
+    $signature_method = $request instanceof OAuthRequest
         ? $request->get_parameter("oauth_signature_method")
         : NULL;
 
@@ -612,7 +612,7 @@ class OAuthServer {
    * try to find the consumer for the provided request's consumer key
    */
   private function get_consumer($request) {
-    $consumer_key = $request instanceof OAuthRequest 
+    $consumer_key = $request instanceof OAuthRequest
         ? $request->get_parameter("oauth_consumer_key")
         : NULL;
 
@@ -684,7 +684,7 @@ class OAuthServer {
       throw new OAuthException(
         'Missing timestamp parameter. The parameter is required'
       );
-    
+
     // verify that timestamp is recentish
     $now = time();
     if (abs($now - $timestamp) > $this->timestamp_threshold) {

--- a/includes/oauth-php/OAuth.php
+++ b/includes/oauth-php/OAuth.php
@@ -100,7 +100,7 @@ abstract class OAuthSignatureMethod {
     // Avoid a timing leak with a (hopefully) time insensitive compare
     $result = 0;
     for ($i = 0; $i < strlen($signature); $i++) {
-      $result |= ord($built[$i]) ^ ord($signature[$i]);
+      $result |= ord($built{[$i]) ^ ord($signature[$i]);
     }
 
     return $result == 0;
@@ -108,9 +108,9 @@ abstract class OAuthSignatureMethod {
 }
 
 /**
- * The HMAC-SHA1 signature method uses the HMAC-SHA1 signature algorithm as defined in [RFC2104]
- * where the Signature Base String is the text and the key is the concatenated values (each first
- * encoded per Parameter Encoding) of the Consumer Secret and Token Secret, separated by an '&'
+ * The HMAC-SHA1 signature method uses the HMAC-SHA1 signature algorithm as defined in [RFC2104] 
+ * where the Signature Base String is the text and the key is the concatenated values (each first 
+ * encoded per Parameter Encoding) of the Consumer Secret and Token Secret, separated by an '&' 
  * character (ASCII code 38) even if empty.
  *   - Chapter 9.2 ("HMAC-SHA1")
  */
@@ -136,7 +136,7 @@ class OAuthSignatureMethod_HMAC_SHA1 extends OAuthSignatureMethod {
 }
 
 /**
- * The PLAINTEXT method does not provide any security protection and SHOULD only be used
+ * The PLAINTEXT method does not provide any security protection and SHOULD only be used 
  * over a secure channel such as HTTPS. It does not use the Signature Base String.
  *   - Chapter 9.4 ("PLAINTEXT")
  */
@@ -146,8 +146,8 @@ class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod {
   }
 
   /**
-   * oauth_signature is set to the concatenated encoded values of the Consumer Secret and
-   * Token Secret, separated by a '&' character (ASCII code 38), even if either secret is
+   * oauth_signature is set to the concatenated encoded values of the Consumer Secret and 
+   * Token Secret, separated by a '&' character (ASCII code 38), even if either secret is 
    * empty. The result MUST be encoded again.
    *   - Chapter 9.4.1 ("Generating Signatures")
    *
@@ -169,10 +169,10 @@ class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod {
 }
 
 /**
- * The RSA-SHA1 signature method uses the RSASSA-PKCS1-v1_5 signature algorithm as defined in
- * [RFC3447] section 8.2 (more simply known as PKCS#1), using SHA-1 as the hash function for
- * EMSA-PKCS1-v1_5. It is assumed that the Consumer has provided its RSA public key in a
- * verified way to the Service Provider, in a manner which is beyond the scope of this
+ * The RSA-SHA1 signature method uses the RSASSA-PKCS1-v1_5 signature algorithm as defined in 
+ * [RFC3447] section 8.2 (more simply known as PKCS#1), using SHA-1 as the hash function for 
+ * EMSA-PKCS1-v1_5. It is assumed that the Consumer has provided its RSA public key in a 
+ * verified way to the Service Provider, in a manner which is beyond the scope of this 
  * specification.
  *   - Chapter 9.3 ("RSA-SHA1")
  */
@@ -573,7 +573,7 @@ class OAuthServer {
   private function get_version(&$request) {
     $version = $request->get_parameter("oauth_version");
     if (!$version) {
-      // Service Providers MUST assume the protocol version to be 1.0 if this parameter is not present.
+      // Service Providers MUST assume the protocol version to be 1.0 if this parameter is not present. 
       // Chapter 7.0 ("Accessing Protected Ressources")
       $version = '1.0';
     }
@@ -587,7 +587,7 @@ class OAuthServer {
    * figure out the signature with some defaults
    */
   private function get_signature_method($request) {
-    $signature_method = $request instanceof OAuthRequest
+    $signature_method = $request instanceof OAuthRequest 
         ? $request->get_parameter("oauth_signature_method")
         : NULL;
 
@@ -612,7 +612,7 @@ class OAuthServer {
    * try to find the consumer for the provided request's consumer key
    */
   private function get_consumer($request) {
-    $consumer_key = $request instanceof OAuthRequest
+    $consumer_key = $request instanceof OAuthRequest 
         ? $request->get_parameter("oauth_consumer_key")
         : NULL;
 
@@ -684,7 +684,7 @@ class OAuthServer {
       throw new OAuthException(
         'Missing timestamp parameter. The parameter is required'
       );
-
+    
     // verify that timestamp is recentish
     $now = time();
     if (abs($now - $timestamp) > $this->timestamp_threshold) {

--- a/includes/oauth-php/OAuth.php
+++ b/includes/oauth-php/OAuth.php
@@ -100,7 +100,7 @@ abstract class OAuthSignatureMethod {
     // Avoid a timing leak with a (hopefully) time insensitive compare
     $result = 0;
     for ($i = 0; $i < strlen($signature); $i++) {
-      $result |= ord($built{$i}) ^ ord($signature[$i]);
+      $result |= ord($built[$i]) ^ ord($signature[$i]);
     }
 
     return $result == 0;

--- a/includes/oauth-php/OAuth.php
+++ b/includes/oauth-php/OAuth.php
@@ -100,7 +100,7 @@ abstract class OAuthSignatureMethod {
     // Avoid a timing leak with a (hopefully) time insensitive compare
     $result = 0;
     for ($i = 0; $i < strlen($signature); $i++) {
-      $result |= ord($built{[$i]) ^ ord($signature[$i]);
+      $result |= ord($built[$i]) ^ ord($signature[$i]);
     }
 
     return $result == 0;

--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -28,13 +28,7 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'refresh', 'https://www.googleapis.com/oauth2/v4/token', 'POST' );
 		$this->set_endpoint( 'userinfo', 'https://www.googleapis.com/oauth2/v3/userinfo', 'GET' );
 
-		$creds              = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->redirect_uri = $creds['redirect_uri'];
-			$this->key          = $creds['key'];
-			$this->secret       = $creds['secret'];
-		}
-
+		$this->init_credentials();
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;
 

--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -29,9 +29,11 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'userinfo', 'https://www.googleapis.com/oauth2/v3/userinfo', 'GET' );
 
 		$creds              = $this->get_credentials();
-		$this->redirect_uri = $creds['redirect_uri'];
-		$this->key          = $creds['key'];
-		$this->secret       = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->redirect_uri = $creds['redirect_uri'];
+			$this->key          = $creds['key'];
+			$this->secret       = $creds['secret'];
+		}
 
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;

--- a/includes/services/extended/500px.php
+++ b/includes/services/extended/500px.php
@@ -26,13 +26,9 @@ class Keyring_Service_500px extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'authenticate', 'https://api.500px.com/v1/oauth/authorize', 'GET' );
 		$this->set_endpoint( 'users', 'https://api.500px.com/v1/users', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
-		
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
+
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;
 

--- a/includes/services/extended/500px.php
+++ b/includes/services/extended/500px.php
@@ -27,10 +27,12 @@ class Keyring_Service_500px extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'users', 'https://api.500px.com/v1/users', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
-
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
+		
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;
 

--- a/includes/services/extended/500px.php
+++ b/includes/services/extended/500px.php
@@ -26,8 +26,7 @@ class Keyring_Service_500px extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'authenticate', 'https://api.500px.com/v1/oauth/authorize', 'GET' );
 		$this->set_endpoint( 'users', 'https://api.500px.com/v1/users', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/eventbrite.php
+++ b/includes/services/extended/eventbrite.php
@@ -24,8 +24,7 @@ class Keyring_Service_Eventbrite extends Keyring_Service_OAuth2 {
 			add_filter( 'keyring_eventbrite_basic_ui_intro', array( $this, 'basic_ui_intro' ) );
 		}
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;
 	}

--- a/includes/services/extended/eventbrite.php
+++ b/includes/services/extended/eventbrite.php
@@ -24,12 +24,8 @@ class Keyring_Service_Eventbrite extends Keyring_Service_OAuth2 {
 			add_filter( 'keyring_eventbrite_basic_ui_intro', array( $this, 'basic_ui_intro' ) );
 		}
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;
 	}

--- a/includes/services/extended/eventbrite.php
+++ b/includes/services/extended/eventbrite.php
@@ -25,10 +25,11 @@ class Keyring_Service_Eventbrite extends Keyring_Service_OAuth2 {
 		}
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
-
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;
 	}

--- a/includes/services/extended/facebook.php
+++ b/includes/services/extended/facebook.php
@@ -22,8 +22,7 @@ class Keyring_Service_Facebook extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'self', 'https://graph.facebook.com/v2.9/me', 'GET' );
 		$this->set_endpoint( 'profile_pic', 'https://graph.facebook.com/v2.9/me/picture/?redirect=false&width=150&height=150', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$kr_nonce           = wp_create_nonce( 'keyring-verify' );
 		$nonce              = wp_create_nonce( 'keyring-verify-facebook' );

--- a/includes/services/extended/facebook.php
+++ b/includes/services/extended/facebook.php
@@ -23,9 +23,11 @@ class Keyring_Service_Facebook extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'profile_pic', 'https://graph.facebook.com/v2.9/me/picture/?redirect=false&width=150&height=150', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$kr_nonce           = wp_create_nonce( 'keyring-verify' );
 		$nonce              = wp_create_nonce( 'keyring-verify-facebook' );

--- a/includes/services/extended/facebook.php
+++ b/includes/services/extended/facebook.php
@@ -22,12 +22,8 @@ class Keyring_Service_Facebook extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'self', 'https://graph.facebook.com/v2.9/me', 'GET' );
 		$this->set_endpoint( 'profile_pic', 'https://graph.facebook.com/v2.9/me/picture/?redirect=false&width=150&height=150', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$kr_nonce           = wp_create_nonce( 'keyring-verify' );
 		$nonce              = wp_create_nonce( 'keyring-verify-facebook' );

--- a/includes/services/extended/fitbit.php
+++ b/includes/services/extended/fitbit.php
@@ -25,9 +25,11 @@ class Keyring_Service_Fitbit extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'profile', 'https://api.fitbit.com/1/user/-/profile.json', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		// Fitbit requires an exact match on Redirect URI, which means we can't send any nonces
 		$this->callback_url = remove_query_arg( array( 'nonce', 'kr_nonce' ), $this->callback_url );

--- a/includes/services/extended/fitbit.php
+++ b/includes/services/extended/fitbit.php
@@ -24,12 +24,8 @@ class Keyring_Service_Fitbit extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'refresh', 'https://api.fitbit.com/oauth2/token', 'POST' );
 		$this->set_endpoint( 'profile', 'https://api.fitbit.com/1/user/-/profile.json', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		// Fitbit requires an exact match on Redirect URI, which means we can't send any nonces
 		$this->callback_url = remove_query_arg( array( 'nonce', 'kr_nonce' ), $this->callback_url );

--- a/includes/services/extended/fitbit.php
+++ b/includes/services/extended/fitbit.php
@@ -24,8 +24,7 @@ class Keyring_Service_Fitbit extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'refresh', 'https://api.fitbit.com/oauth2/token', 'POST' );
 		$this->set_endpoint( 'profile', 'https://api.fitbit.com/1/user/-/profile.json', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		// Fitbit requires an exact match on Redirect URI, which means we can't send any nonces
 		$this->callback_url = remove_query_arg( array( 'nonce', 'kr_nonce' ), $this->callback_url );

--- a/includes/services/extended/flickr.php
+++ b/includes/services/extended/flickr.php
@@ -22,9 +22,11 @@ class Keyring_Service_Flickr extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://www.flickr.com/services/oauth/access_token', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/flickr.php
+++ b/includes/services/extended/flickr.php
@@ -21,8 +21,7 @@ class Keyring_Service_Flickr extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'authorize', 'https://www.flickr.com/services/oauth/authorize', 'GET' );
 		$this->set_endpoint( 'access_token', 'https://www.flickr.com/services/oauth/access_token', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/flickr.php
+++ b/includes/services/extended/flickr.php
@@ -21,12 +21,8 @@ class Keyring_Service_Flickr extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'authorize', 'https://www.flickr.com/services/oauth/authorize', 'GET' );
 		$this->set_endpoint( 'access_token', 'https://www.flickr.com/services/oauth/access_token', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/foursquare.php
+++ b/includes/services/extended/foursquare.php
@@ -26,9 +26,11 @@ class Keyring_Service_Foursquare extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'self', 'https://api.foursquare.com/v2/users/self', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 	}
 
 	function basic_ui_intro() {

--- a/includes/services/extended/foursquare.php
+++ b/includes/services/extended/foursquare.php
@@ -25,8 +25,7 @@ class Keyring_Service_Foursquare extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://foursquare.com/oauth2/access_token', 'GET' );
 		$this->set_endpoint( 'self', 'https://api.foursquare.com/v2/users/self', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 	}
 
 	function basic_ui_intro() {

--- a/includes/services/extended/foursquare.php
+++ b/includes/services/extended/foursquare.php
@@ -25,12 +25,8 @@ class Keyring_Service_Foursquare extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://foursquare.com/oauth2/access_token', 'GET' );
 		$this->set_endpoint( 'self', 'https://api.foursquare.com/v2/users/self', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 	}
 
 	function basic_ui_intro() {

--- a/includes/services/extended/github.php
+++ b/includes/services/extended/github.php
@@ -23,10 +23,7 @@ class Keyring_Service_Github extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://github.com/login/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'self', 'https://api.github.com/user', 'GET' );
 
-		$creds = $this->get_credentials();
-
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/github.php
+++ b/includes/services/extended/github.php
@@ -25,11 +25,8 @@ class Keyring_Service_Github extends Keyring_Service_OAuth2 {
 
 		$creds = $this->get_credentials();
 
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/github.php
+++ b/includes/services/extended/github.php
@@ -25,9 +25,11 @@ class Keyring_Service_Github extends Keyring_Service_OAuth2 {
 
 		$creds = $this->get_credentials();
 
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/instagram-basic-display.php
+++ b/includes/services/extended/instagram-basic-display.php
@@ -24,10 +24,8 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'refresh_token', 'https://graph.instagram.com/refresh_access_token', 'GET' );
 		$this->set_endpoint( 'self', 'https://graph.instagram.com/me', 'GET' );
 
-		$creds = $this->get_credentials();
+		$this->init_credentials();
 
-		$this->init_credentials( $creds );
-		
 		// The new Instagram API is very fussy about the redirect uri, so this strips the query params
 		// from the default admin url
 		$admin_url          = Keyring_Util::admin_url();

--- a/includes/services/extended/instagram-basic-display.php
+++ b/includes/services/extended/instagram-basic-display.php
@@ -26,10 +26,11 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 
 		$creds = $this->get_credentials();
 
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
-
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 		// The new Instagram API is very fussy about the redirect uri, so this strips the query params
 		// from the default admin url
 		$admin_url          = Keyring_Util::admin_url();

--- a/includes/services/extended/instagram-basic-display.php
+++ b/includes/services/extended/instagram-basic-display.php
@@ -26,11 +26,8 @@ class Keyring_Service_Instagram_Basic_Display extends Keyring_Service_OAuth2 {
 
 		$creds = $this->get_credentials();
 
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$this->init_credentials( $creds );
+		
 		// The new Instagram API is very fussy about the redirect uri, so this strips the query params
 		// from the default admin url
 		$admin_url          = Keyring_Util::admin_url();

--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -22,12 +22,8 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://api.instagram.com/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'self', 'https://api.instagram.com/v1/users/self/', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->authorization_header    = false; // Send in querystring
 		$this->authorization_parameter = 'access_token';

--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -22,8 +22,7 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://api.instagram.com/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'self', 'https://api.instagram.com/v1/users/self/', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->authorization_header    = false; // Send in querystring
 		$this->authorization_parameter = 'access_token';

--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -23,9 +23,11 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'self', 'https://api.instagram.com/v1/users/self/', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->authorization_header    = false; // Send in querystring
 		$this->authorization_parameter = 'access_token';

--- a/includes/services/extended/instapaper.php
+++ b/includes/services/extended/instapaper.php
@@ -23,12 +23,8 @@ class Keyring_Service_Instapaper extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://www.instapaper.com/api/1/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'verify', 'https://www.instapaper.com/api/1/account/verify_credentials', 'POST' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		};
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/instapaper.php
+++ b/includes/services/extended/instapaper.php
@@ -23,8 +23,7 @@ class Keyring_Service_Instapaper extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://www.instapaper.com/api/1/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'verify', 'https://www.instapaper.com/api/1/account/verify_credentials', 'POST' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/instapaper.php
+++ b/includes/services/extended/instapaper.php
@@ -24,9 +24,11 @@ class Keyring_Service_Instapaper extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'verify', 'https://www.instapaper.com/api/1/account/verify_credentials', 'POST' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		};
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/jetpack.php
+++ b/includes/services/extended/jetpack.php
@@ -23,12 +23,8 @@ class Keyring_Service_Jetpack extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://public-api.wordpress.com/oauth2/token', 'POST' );
 		$this->set_endpoint( 'self', 'https://public-api.wordpress.com/rest/v1/me/', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->authorization_header = 'Bearer';
 

--- a/includes/services/extended/jetpack.php
+++ b/includes/services/extended/jetpack.php
@@ -23,8 +23,7 @@ class Keyring_Service_Jetpack extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://public-api.wordpress.com/oauth2/token', 'POST' );
 		$this->set_endpoint( 'self', 'https://public-api.wordpress.com/rest/v1/me/', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->authorization_header = 'Bearer';
 

--- a/includes/services/extended/jetpack.php
+++ b/includes/services/extended/jetpack.php
@@ -24,9 +24,11 @@ class Keyring_Service_Jetpack extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'self', 'https://public-api.wordpress.com/rest/v1/me/', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->authorization_header = 'Bearer';
 

--- a/includes/services/extended/jetpack.php
+++ b/includes/services/extended/jetpack.php
@@ -23,7 +23,7 @@ class Keyring_Service_Jetpack extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://public-api.wordpress.com/oauth2/token', 'POST' );
 		$this->set_endpoint( 'self', 'https://public-api.wordpress.com/rest/v1/me/', 'GET' );
 
-		$this->init_credentials();
+		$creds = $this->init_credentials();
 
 		$this->authorization_header = 'Bearer';
 

--- a/includes/services/extended/linkedin.php
+++ b/includes/services/extended/linkedin.php
@@ -25,9 +25,11 @@ class Keyring_Service_LinkedIn extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'profile_pic', 'https://api.linkedin.com/v2/me/picture-urls::(original)/', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->consumer             = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method     = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/linkedin.php
+++ b/includes/services/extended/linkedin.php
@@ -24,8 +24,7 @@ class Keyring_Service_LinkedIn extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'self', 'https://api.linkedin.com/v2/me', 'GET' );
 		$this->set_endpoint( 'profile_pic', 'https://api.linkedin.com/v2/me/picture-urls::(original)/', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->consumer             = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method     = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/linkedin.php
+++ b/includes/services/extended/linkedin.php
@@ -24,12 +24,8 @@ class Keyring_Service_LinkedIn extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'self', 'https://api.linkedin.com/v2/me', 'GET' );
 		$this->set_endpoint( 'profile_pic', 'https://api.linkedin.com/v2/me/picture-urls::(original)/', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->consumer             = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method     = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/moves.php
+++ b/includes/services/extended/moves.php
@@ -40,8 +40,7 @@ class Keyring_Service_Moves extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'verify_token', 'https://api.moves-app.com/oauth/v1/tokeninfo', 'GET' );
 		$this->set_endpoint( 'profile', 'https://api.moves-app.com/api/1.1/user/profile', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		// Moves requires an exact match on Redirect URI, which means we can't send any nonces
 		$this->callback_url = remove_query_arg( array( 'nonce', 'kr_nonce' ), $this->callback_url );

--- a/includes/services/extended/moves.php
+++ b/includes/services/extended/moves.php
@@ -41,9 +41,11 @@ class Keyring_Service_Moves extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'profile', 'https://api.moves-app.com/api/1.1/user/profile', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		// Moves requires an exact match on Redirect URI, which means we can't send any nonces
 		$this->callback_url = remove_query_arg( array( 'nonce', 'kr_nonce' ), $this->callback_url );

--- a/includes/services/extended/moves.php
+++ b/includes/services/extended/moves.php
@@ -40,12 +40,8 @@ class Keyring_Service_Moves extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'verify_token', 'https://api.moves-app.com/oauth/v1/tokeninfo', 'GET' );
 		$this->set_endpoint( 'profile', 'https://api.moves-app.com/api/1.1/user/profile', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		// Moves requires an exact match on Redirect URI, which means we can't send any nonces
 		$this->callback_url = remove_query_arg( array( 'nonce', 'kr_nonce' ), $this->callback_url );

--- a/includes/services/extended/nest.php
+++ b/includes/services/extended/nest.php
@@ -22,12 +22,8 @@ class Keyring_Service_Nest extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://api.home.nest.com/oauth2/access_token', 'POST' );
 		$this->set_endpoint( 'self', 'https://developer-api.nest.com/', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->authorization_header = 'Bearer';
 

--- a/includes/services/extended/nest.php
+++ b/includes/services/extended/nest.php
@@ -22,8 +22,7 @@ class Keyring_Service_Nest extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://api.home.nest.com/oauth2/access_token', 'POST' );
 		$this->set_endpoint( 'self', 'https://developer-api.nest.com/', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->authorization_header = 'Bearer';
 

--- a/includes/services/extended/nest.php
+++ b/includes/services/extended/nest.php
@@ -23,9 +23,11 @@ class Keyring_Service_Nest extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'self', 'https://developer-api.nest.com/', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->authorization_header = 'Bearer';
 

--- a/includes/services/extended/pinterest.php
+++ b/includes/services/extended/pinterest.php
@@ -24,9 +24,11 @@ class Keyring_Service_Pinterest extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'self', 'https://api.pinterest.com/v1/me/?fields=first_name,last_name,username,image', 'GET' ); // undocumented, but required to get the `image` in a single request
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		// Send auth token in query string
 		$this->authorization_header    = false;

--- a/includes/services/extended/pinterest.php
+++ b/includes/services/extended/pinterest.php
@@ -23,8 +23,7 @@ class Keyring_Service_Pinterest extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://api.pinterest.com/v1/oauth/token', 'POST' );
 		$this->set_endpoint( 'self', 'https://api.pinterest.com/v1/me/?fields=first_name,last_name,username,image', 'GET' ); // undocumented, but required to get the `image` in a single request
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		// Send auth token in query string
 		$this->authorization_header    = false;

--- a/includes/services/extended/pinterest.php
+++ b/includes/services/extended/pinterest.php
@@ -23,12 +23,8 @@ class Keyring_Service_Pinterest extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://api.pinterest.com/v1/oauth/token', 'POST' );
 		$this->set_endpoint( 'self', 'https://api.pinterest.com/v1/me/?fields=first_name,last_name,username,image', 'GET' ); // undocumented, but required to get the `image` in a single request
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		// Send auth token in query string
 		$this->authorization_header    = false;

--- a/includes/services/extended/pocket.php
+++ b/includes/services/extended/pocket.php
@@ -18,7 +18,9 @@ class Keyring_Service_Pocket extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'access_token', 'https://getpocket.com/v3/oauth/authorize', 'POST' );
 
 		$creds              = $this->get_credentials();
-		$this->key          = $creds['key'];
+		if ( ! empty( $creds ) ) {
+			$this->key    = $creds['key'];
+		}
 		$kr_nonce           = wp_create_nonce( 'keyring-verify' );
 		$nonce              = wp_create_nonce( 'keyring-verify-pocket' );
 		$this->redirect_uri = Keyring_Util::admin_url(

--- a/includes/services/extended/runkeeper.php
+++ b/includes/services/extended/runkeeper.php
@@ -24,12 +24,8 @@ class Keyring_Service_RunKeeper extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'user', 'https://api.runkeeper.com/user', 'GET' );
 		$this->set_endpoint( 'profile', 'https://api.runkeeper.com/profile', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;

--- a/includes/services/extended/runkeeper.php
+++ b/includes/services/extended/runkeeper.php
@@ -25,9 +25,11 @@ class Keyring_Service_RunKeeper extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'profile', 'https://api.runkeeper.com/profile', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;

--- a/includes/services/extended/runkeeper.php
+++ b/includes/services/extended/runkeeper.php
@@ -24,8 +24,7 @@ class Keyring_Service_RunKeeper extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'user', 'https://api.runkeeper.com/user', 'GET' );
 		$this->set_endpoint( 'profile', 'https://api.runkeeper.com/profile', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;

--- a/includes/services/extended/strava.php
+++ b/includes/services/extended/strava.php
@@ -24,8 +24,7 @@ class Keyring_Service_Strava extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'deauthorize', 'https://www.strava.com/oauth/deauthorize', 'POST' );
 		$this->set_endpoint( 'user', 'https://www.strava.com/api/v3/athlete', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;

--- a/includes/services/extended/strava.php
+++ b/includes/services/extended/strava.php
@@ -24,12 +24,8 @@ class Keyring_Service_Strava extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'deauthorize', 'https://www.strava.com/oauth/deauthorize', 'POST' );
 		$this->set_endpoint( 'user', 'https://www.strava.com/api/v3/athlete', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;

--- a/includes/services/extended/strava.php
+++ b/includes/services/extended/strava.php
@@ -25,9 +25,11 @@ class Keyring_Service_Strava extends Keyring_Service_OAuth2 {
 		$this->set_endpoint( 'user', 'https://www.strava.com/api/v3/athlete', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->authorization_header    = 'Bearer';
 		$this->authorization_parameter = false;

--- a/includes/services/extended/tripit.php
+++ b/includes/services/extended/tripit.php
@@ -26,9 +26,11 @@ class Keyring_Service_TripIt extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'verify', 'https://api.tripit.com/v1/get/profile/id/me', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/tripit.php
+++ b/includes/services/extended/tripit.php
@@ -25,12 +25,8 @@ class Keyring_Service_TripIt extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://api.tripit.com/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'verify', 'https://api.tripit.com/v1/get/profile/id/me', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/tripit.php
+++ b/includes/services/extended/tripit.php
@@ -25,8 +25,7 @@ class Keyring_Service_TripIt extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://api.tripit.com/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'verify', 'https://api.tripit.com/v1/get/profile/id/me', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/tumblr.php
+++ b/includes/services/extended/tumblr.php
@@ -23,9 +23,11 @@ class Keyring_Service_Tumblr extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'self', 'https://api.tumblr.com/v2/user/info', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/tumblr.php
+++ b/includes/services/extended/tumblr.php
@@ -22,12 +22,8 @@ class Keyring_Service_Tumblr extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://www.tumblr.com/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'self', 'https://api.tumblr.com/v2/user/info', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/tumblr.php
+++ b/includes/services/extended/tumblr.php
@@ -22,8 +22,7 @@ class Keyring_Service_Tumblr extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://www.tumblr.com/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'self', 'https://api.tumblr.com/v2/user/info', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/twitter.php
+++ b/includes/services/extended/twitter.php
@@ -26,9 +26,11 @@ class Keyring_Service_Twitter extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'verify', 'https://api.twitter.com/1.1/account/verify_credentials.json', 'GET' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/twitter.php
+++ b/includes/services/extended/twitter.php
@@ -25,8 +25,7 @@ class Keyring_Service_Twitter extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://twitter.com/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'verify', 'https://api.twitter.com/1.1/account/verify_credentials.json', 'GET' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/twitter.php
+++ b/includes/services/extended/twitter.php
@@ -25,12 +25,8 @@ class Keyring_Service_Twitter extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://twitter.com/oauth/access_token', 'POST' );
 		$this->set_endpoint( 'verify', 'https://api.twitter.com/1.1/account/verify_credentials.json', 'GET' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/yahoo.php
+++ b/includes/services/extended/yahoo.php
@@ -21,12 +21,8 @@ class Keyring_Service_Yahoo extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'authorize', 'https://api.login.yahoo.com/oauth/v2/request_auth', 'GET' );
 		$this->set_endpoint( 'access_token', 'https://api.login.yahoo.com/oauth/v2/get_token', 'POST' );
 
-		$creds        = $this->get_credentials();
-		if ( ! empty( $creds ) ) {
-			$this->app_id = $creds['app_id'];
-			$this->key    = $creds['key'];
-			$this->secret = $creds['secret'];
-		}
+		$creds = $this->get_credentials();
+		$this->init_credentials( $creds );
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/yahoo.php
+++ b/includes/services/extended/yahoo.php
@@ -22,9 +22,11 @@ class Keyring_Service_Yahoo extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'access_token', 'https://api.login.yahoo.com/oauth/v2/get_token', 'POST' );
 
 		$creds        = $this->get_credentials();
-		$this->app_id = $creds['app_id'];
-		$this->key    = $creds['key'];
-		$this->secret = $creds['secret'];
+		if ( ! empty( $creds ) ) {
+			$this->app_id = $creds['app_id'];
+			$this->key    = $creds['key'];
+			$this->secret = $creds['secret'];
+		}
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/includes/services/extended/yahoo.php
+++ b/includes/services/extended/yahoo.php
@@ -21,8 +21,7 @@ class Keyring_Service_Yahoo extends Keyring_Service_OAuth1 {
 		$this->set_endpoint( 'authorize', 'https://api.login.yahoo.com/oauth/v2/request_auth', 'GET' );
 		$this->set_endpoint( 'access_token', 'https://api.login.yahoo.com/oauth/v2/get_token', 'POST' );
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials();
 
 		$this->consumer         = new OAuthConsumer( $this->key, $this->secret, $this->callback_url );
 		$this->signature_method = new OAuthSignatureMethod_HMAC_SHA1;

--- a/service.php
+++ b/service.php
@@ -171,8 +171,7 @@ abstract class Keyring_Service {
 		$api_key    = '';
 		$api_secret = '';
 
-		$creds = $this->get_credentials();
-		$this->init_credentials( $creds );
+		$this->init_credentials( );
 
 		echo apply_filters( 'keyring_' . $this->get_name() . '_basic_ui_intro', '' );
 
@@ -265,12 +264,16 @@ abstract class Keyring_Service {
 	 *
 	 * @param Mixed $credentials
 	 */
-	function init_credentials( $credentials ) {
-		if ( ! empty( $credentials ) && is_array( $credentials ) ) {
+	function init_credentials( $credentials = null ) {
+		if( ! isset ( $credentials ) ) {
+			$credentials = $this->get_credentials();
+		}
+		if ( is_array( $credentials ) ) {
 			$this->app_id = $credentials['app_id'] ? $credentials['app_id'] : null;
 			$this->key    = $credentials['key'] ? $credentials['key'] : null;
 			$this->secret = $credentials['secret'] ? $credentials['secret'] : null;
 		}
+		return $credentials;
 	}
 
 	/**

--- a/service.php
+++ b/service.php
@@ -172,11 +172,7 @@ abstract class Keyring_Service {
 		$api_secret = '';
 
 		$creds = $this->get_credentials();
-		if ( $creds ) {
-			$app_id     = $creds['app_id'];
-			$api_key    = $creds['key'];
-			$api_secret = $creds['secret'];
-		}
+		$this->init_credentials( $creds );
 
 		echo apply_filters( 'keyring_' . $this->get_name() . '_basic_ui_intro', '' );
 
@@ -261,6 +257,20 @@ abstract class Keyring_Service {
 		}
 
 		return apply_filters( 'keyring_service_credentials', $creds, $this->get_name() );
+	}
+
+		/**
+	 * Set the basic credential properties based
+	 * on an Array of credentials
+	 *
+	 * @param Mixed $credentials
+	 */
+	function init_credentials( $credentials ) {
+		if ( ! empty( $credentials ) && is_array( $credentials ) ) {
+			$this->app_id = $credentials['app_id'] ? $credentials['app_id'] : null;
+			$this->key    = $credentials['key'] ? $credentials['key'] : null;
+			$this->secret = $credentials['secret'] ? $credentials['secret'] : null;
+		}
 	}
 
 	/**

--- a/service.php
+++ b/service.php
@@ -265,7 +265,7 @@ abstract class Keyring_Service {
 	 * @param Mixed $credentials
 	 */
 	function init_credentials( $credentials = null ) {
-		if( ! isset ( $credentials ) ) {
+		if( empty( $credentials ) ) {
 			$credentials = $this->get_credentials();
 		}
 		if ( is_array( $credentials ) ) {

--- a/service.php
+++ b/service.php
@@ -269,10 +269,10 @@ abstract class Keyring_Service {
 			$credentials = $this->get_credentials();
 		}
 		if ( is_array( $credentials ) ) {
-			$this->app_id = $credentials['app_id'] ? $credentials['app_id'] : null;
-			$this->key    = $credentials['key'] ? $credentials['key'] : null;
-			$this->secret = $credentials['secret'] ? $credentials['secret'] : null;
-			$this->redirect_uri = $credentials['redirect_uri'] ? $credentials['redirect_uri'] : null;
+			$this->app_id = ! empty( $credentials['app_id'] ) ? $credentials['app_id'] : null;
+			$this->key    = ! empty( $credentials['key'] ) ? $credentials['key'] : null;
+			$this->secret = ! empty( $credentials['secret'] ) ? $credentials['secret'] : null;
+			$this->redirect_uri = ! empty( $credentials['redirect_uri'] ) ? $credentials['redirect_uri'] : null;
 		}
 		return $credentials;
 	}

--- a/service.php
+++ b/service.php
@@ -272,6 +272,7 @@ abstract class Keyring_Service {
 			$this->app_id = $credentials['app_id'] ? $credentials['app_id'] : null;
 			$this->key    = $credentials['key'] ? $credentials['key'] : null;
 			$this->secret = $credentials['secret'] ? $credentials['secret'] : null;
+			$this->redirect_uri = $credentials['redirect_uri'] ? $credentials['redirect_uri'] : null;
 		}
 		return $credentials;
 	}


### PR DESCRIPTION
## Description
Running Keyring on a site with WP_DEBUG=TRUE under PHP7.4  results on some deprecation and notices:
- `Notice"Trying to access array offset on value of type bool`
- `Deprecated: Array and string offset access syntax with curly braces is deprecated`

Note: There may be other places where this needs to be fixed, this PR resolves the ones that appear in the front end and admin on a fresh install.

## Steps to test
1. Install Keyring on a site running PHP 7.4
1. Set `define( 'WP_DEBUG', true);` in wp-config.php
1. View the site and/or wp-admin


