### PR TITLE
Add CS workflow

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,0 +1,51 @@
+# yamllint disable rule:line-length
+
+name: Code Style
+
+on:
+  pull_request:
+  push:
+    branches:
+      - trunk
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: ['7.4']
+
+    name: PHPCS
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.*') }}
+          restore-keys: |
+            composer-${{ runner.os }}-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-
+            composer-
+
+      - name: Install dependencies
+        run: |
+          composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Check code style
+        run: |
+          composer php:lint


### PR DESCRIPTION
This PR:

 - [x] Adds code style checks since Travis CI is out of use.
 - [x] Uses all necessary caching to ensure fastest builds.
 - [x] This is a follow-up to #83, for which GitHub can't handle update

GitHub actions might [need to be enabled](https://github.com/beaulebens/keyring/settings/actions) for this repository, but this is [as hard as checking a checkbox](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#managing-github-actions-permissions-for-your-repository).

There's a slight annoyance with GitHub actions: they won't run a workflow before you have just one enabled.

