### PR TITLE
clean unused misleading param in get_tokens()

### DIFF
--- a/service.php
+++ b/service.php
@@ -334,7 +334,7 @@ abstract class Keyring_Service {
 		return $this->token;
 	}
 
-	function get_tokens( $id = false ) {
+	function get_tokens() {
 		$c = get_called_class();
 		return $this->store->get_tokens(
 			array(


### PR DESCRIPTION
Description
---
This pull request cleans unused param that is misleading since at first sight we might think that by supplying `id` as a param to `get_tokens($id)` would return unique result. 
In reality, this param is not used at all. 
After check for possible parent/child classes, it looks like this is just a leftover.