### PR TITLE
Handle error messages from services.

### DIFF
--- a/admin-ui.php
+++ b/admin-ui.php
@@ -53,6 +53,15 @@ class Keyring_Admin_UI {
 	function admin_page_load() {
 		$this->keyring = Keyring::init();
 		add_action( 'admin_head', array( $this, 'inline_css' ) );
+
+		// Disables the default behavior. Keyring will handle the error parameter by displaying a readable text to user.
+		add_filter(
+			'removable_query_args',
+			function ( $args ) {
+				array_splice( $args, array_search( 'error', $args ), 1 );
+				return $args;
+			}
+		);
 	}
 
 	function admin_page_header( $screen = false ) {
@@ -145,6 +154,13 @@ class Keyring_Admin_UI {
 			} else {
 				Keyring::message( __( 'This service does not currently support connection testing.', 'keyring' ) );
 			}
+		}
+
+		// Handle errors.
+		if ( isset( $_REQUEST['error'] ) ) {
+			$service = $_REQUEST['service'];
+			$error   = apply_filters( "keyring_handle_error_{$service}", $_REQUEST['error'], $_REQUEST );
+			Keyring::error( $error, true, false );
 		}
 
 		// Set up our defaults


### PR DESCRIPTION
This PR closes #101.

**Details about the code in PR:**
* The 'removable_query_args' filter was added because Wordpress introduced a feature [to remove certain parameters globally](https://core.trac.wordpress.org/ticket/23367) whenever present in URLs. Obviously, other services are going to return these parameters sometimes esp. error and message. So, this filter removes it for this plugin's admin UI to handle errors and show it to the user.
* The keyring_handle_error_SERVICENAME filter allows services to handle their own error messages considering that errors are generally service/API-specific.
* The action is set to services (in `redirect_incoming_verify`) to avoid it getting stuck in a redirect loop as that redirect handling code will keep getting triggered as long as error exists in the URL.
* `get_error_messages` handles only 2 error codes since those were the ones I was able to reproduce (firstly in the issue I created and again during testing--the 1004 happens when user cancels, the 1006 one happens when either user cancels or the client secret is invalid ). I couldn't find any documentation that lists all the possible error codes (perhaps other APIs do and those could be added by other contributors).
* On the same note as above, I found that Google does always sends error message as an underscored-slug text so I've humanized that and returned as a fallback error message that's better readable by a user.