### PR TITLE
Update readme.txt after #84

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,6 @@ Out of the box, Keyring currently comes with base Service definitions for:
 And includes ready-to-use definitions for:
 
 * [500px](https://500px.com/)
-* [Delicious](https://delicious.com/)
 * [Eventbrite](https://eventbrite.com/)
 * [Facebook](https://facebook.com/)
 * [Fitbit](https://fitbit.com/)


### PR DESCRIPTION
Delicious was removed by #84, but it is still mentioned in the readme.txt.
