### PR TITLE
Remove singleton from Keyring::init for PHP8.1+ compatibility

### DIFF
--- a/service.php
+++ b/service.php
@@ -70,17 +70,13 @@ abstract class Keyring_Service {
 	}
 
 	static function init() {
-		static $instance = false;
-
-		if ( ! $instance ) {
-			$class    = get_called_class();
-			$services = Keyring::get_registered_services();
-			if ( in_array( $class::NAME, array_keys( $services ), true ) ) {
-				$instance = $services[ $class::NAME ];
-			} else {
-				$instance = new $class;
-				Keyring::register_service( $instance );
-			}
+		$class    = get_called_class();
+		$services = Keyring::get_registered_services();
+		if ( in_array( $class::NAME, array_keys( $services ), true ) ) {
+			$instance = $services[ $class::NAME ];
+		} else {
+			$instance = new $class;
+			Keyring::register_service( $instance );
 		}
 
 		return $instance;


### PR DESCRIPTION
Starting from PHP 8.1.0, using Keyring only provides a single service:

<img width="571" alt="Screenshot 2022-12-21 at 19 34 01" src="https://user-images.githubusercontent.com/1620929/208978578-0552fec3-4b30-4027-9eda-af5c580fd6e4.png">

The reason for that is that in 8.1 the behavior for static variables has been altered (likely [related](https://bugs.php.net/bug.php?id=75474)):

| Before | After |
| :-: | :-: |
| <img width="601" alt="Screenshot 2022-12-21 at 19 23 56" src="https://user-images.githubusercontent.com/1620929/208978675-d14b86b5-18ea-4ade-828d-5ff73ff508bd.png"> | <img width="585" alt="Screenshot 2022-12-21 at 19 23 45" src="https://user-images.githubusercontent.com/1620929/208978671-0b0097c3-94c5-4058-89cd-2277829b3c1f.png"> |

The most straightforward fix is to remove `init` from using the `static` variable. The impact shouldn't be too big as `Keyring` is also a singleton and `$registered_services` contain all the initialized services.

@beaulebens 