### PR TITLE
Update old references to developer's guide

### DIFF
--- a/keyring.php
+++ b/keyring.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Keyring
-Plugin URI: http://dentedreality.com.au/projects/wp-keyring/
+Plugin URI: https://beaulebens.com/projects/wp-keyring/
 Description: Keyring helps you manage your keys. It provides a generic, very hookable framework for connecting to remote systems and managing your access tokens, username/password combos etc for those services. On its own it doesn't do much, but it enables other plugins to do things that require authorization to act on your behalf.
 Version: 3.0
 Author: Beau Lebens

--- a/languages/keyring.po
+++ b/languages/keyring.po
@@ -635,7 +635,7 @@ msgid "API Secret"
 msgstr ""
 
 #. Plugin URI of the plugin/theme
-msgid "http://dentedreality.com.au/projects/wp-keyring/"
+msgid "https://beaulebens.com/projects/wp-keyring/"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,7 @@ And includes ready-to-use definitions for:
 * [Yahoo! Updates](https://yahoo.com/)
 * [YouTube](https://youtube.com/)
 
-You can very easily write your own Service definitions and then use all the power of Keyring to hook into that authentication flow. See the [Keyring Developer's Guide](http://dentedreality.com.au/projects/wp-keyring/) for more details.
+You can very easily write your own Service definitions and then use all the power of Keyring to hook into that authentication flow. See the [Keyring Developer's Guide](https://beaulebens.com/projects/wp-keyring/) for more details.
 
 Contributions are welcome via [Github pull request](https://github.com/beaulebens/keyring).
 
@@ -60,7 +60,7 @@ Contributions are welcome via [Github pull request](https://github.com/beauleben
 
 = How Do I Use Keyring in my Plugin? =
 
-Check out the [Keyring Developer's Guide](http://dentedreality.com.au/projects/wp-keyring/).
+Check out the [Keyring Developer's Guide](https://beaulebens.com/projects/wp-keyring/).
 
 See [Keyring Social Importers](http://wordpress.org/plugins/keyring-social-importers/) for an example. You can also extend Keyring Service classes directly, rather than attaching the service as a property to an object (like the Importers do).
 


### PR DESCRIPTION
This is a simple Pull Request to update all references to the old developer's guide (http://dentedreality.com.au/projects/wp-keyring/) to the correct one (https://beaulebens.com/projects/wp-keyring/).