### PR TITLE
Bump tested up to current WordPress Stable version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beaulebens, mdawaffe, jshreve, jkudish, automattic
 Tags: authentication, security, oauth, http basic, authorization, facebook, foursquare, instagram, twitter, google
 Requires at least: 4.0
-Tested up to: 6.2
+Tested up to: 6.6
 Stable Tag: 3.0
 
 An authentication framework that handles authorization/communication with most popular web services.


### PR DESCRIPTION
In my testing, Keyring is still working well for WordPress 6.6

Currently, the version is more than 3 behind WordPress Core, so it's displaying the yellow banner of gloom. This will fix that.